### PR TITLE
NUCCORE-1138 L2 cache configuration not reset

### DIFF
--- a/src/java/org/datanucleus/ExecutionContextImpl.java
+++ b/src/java/org/datanucleus/ExecutionContextImpl.java
@@ -382,6 +382,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                 return new ThreadContextInfo();
             }
         };
+        setLevel2Cache(true);
     }
 
     /**


### PR DESCRIPTION
NUCCORE-1138 L2 cache configuration not reset when getting
