### PR TITLE
NUCCORE-1208

### DIFF
--- a/src/main/java/org/datanucleus/cache/SoftRefCache.java
+++ b/src/main/java/org/datanucleus/cache/SoftRefCache.java
@@ -65,6 +65,9 @@ public class SoftRefCache implements Level1Cache
 
 	public void clear()
 	{
+		if (isEmpty()) {
+			return;
+		}
 		softCache.clear();
 	}
     

--- a/src/main/java/org/datanucleus/util/ReferenceValueMap.java
+++ b/src/main/java/org/datanucleus/util/ReferenceValueMap.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public abstract class ReferenceValueMap implements Map, Cloneable
      **/
     public ReferenceValueMap()
     {
-        map = new HashMap();
+        map = new LinkedHashMap();
     }
 
     /**
@@ -55,7 +56,7 @@ public abstract class ReferenceValueMap implements Map, Cloneable
      **/
     public ReferenceValueMap(int initial_capacity)
     {
-        map = new HashMap(initial_capacity);
+        map = new LinkedHashMap(initial_capacity);
     }
 
     /**
@@ -65,7 +66,7 @@ public abstract class ReferenceValueMap implements Map, Cloneable
      **/
     public ReferenceValueMap(int initial_capacity,float load_factor)
     {
-        map = new HashMap(initial_capacity, load_factor);
+        map = new LinkedHashMap(initial_capacity, load_factor);
     }
 
     /**
@@ -74,7 +75,7 @@ public abstract class ReferenceValueMap implements Map, Cloneable
      **/
     public ReferenceValueMap(Map m)
     {
-        map = new HashMap();
+        map = new LinkedHashMap();
         putAll(m);
     }
 
@@ -97,7 +98,7 @@ public abstract class ReferenceValueMap implements Map, Cloneable
             // Do nothing
         }
 
-        rvm.map = (HashMap)map.clone(); // to preserve initialCapacity, loadFactor
+        rvm.map = (LinkedHashMap)map.clone(); // to preserve initialCapacity, loadFactor
         rvm.map.clear();
         rvm.reaped = new ReferenceQueue();
         rvm.putAll(entrySet());
@@ -292,7 +293,7 @@ public abstract class ReferenceValueMap implements Map, Cloneable
 
         Set s = map.entrySet();
         Iterator i = s.iterator();
-        HashMap m = new HashMap(s.size());
+        LinkedHashMap m = new LinkedHashMap(s.size());
 
         while (i.hasNext())
         {


### PR DESCRIPTION
LinkedHashMap saves up to 4% cpu during commit() when 1st level cache is cleared.
