### PR TITLE
Fixed missing '>' characters in toString() methods

### DIFF
--- a/src/main/java/org/datanucleus/metadata/FetchGroupMetaData.java
+++ b/src/main/java/org/datanucleus/metadata/FetchGroupMetaData.java
@@ -157,7 +157,7 @@ public class FetchGroupMetaData extends MetaData
     public String toString(String prefix, String indent)
     {
         StringBuilder sb = new StringBuilder();
-        sb.append(prefix).append("<fetch-group name=\"" + name + "\"\n");
+        sb.append(prefix).append("<fetch-group name=\"" + name + "\">\n");
 
         // Add fetch-groups
         if (fetchGroups != null)

--- a/src/main/java/org/datanucleus/metadata/FetchPlanMetaData.java
+++ b/src/main/java/org/datanucleus/metadata/FetchPlanMetaData.java
@@ -166,7 +166,7 @@ public class FetchPlanMetaData extends MetaData
         StringBuilder sb = new StringBuilder();
         sb.append(prefix).append("<fetch-plan name=\"" + name + "\"" + 
             " max-fetch-depth=\"" + maxFetchDepth + "\"" +
-            " fetch-size=\"" + fetchSize + "\"\n");
+            " fetch-size=\"" + fetchSize + "\">\n");
 
         // Add fetch-groups
         Iterator iter = fetchGroups.iterator();


### PR DESCRIPTION
FetchGroupMetadata & FetchPlanMetadata would not close
their opening elements properly in their toString() output.
