### PR TITLE
Fix NPE in PersistenceUnitMetaData.java

### DIFF
--- a/src/main/java/org/datanucleus/metadata/PersistenceUnitMetaData.java
+++ b/src/main/java/org/datanucleus/metadata/PersistenceUnitMetaData.java
@@ -210,7 +210,7 @@ public class PersistenceUnitMetaData extends MetaData
 
     public void addClassNames(Set<String> classNames)
     {
-        if (classNames == null)
+        if (this.classNames == null)
         {
             this.classNames = new HashSet();
         }


### PR DESCRIPTION
In method ```addClassNames(Set<String> classNames)```, parameter name ```classNames``` shadows class instance variable. The variable initilialisation check on line 213 should reference the instance variable ```this.classNames```, rather than the parameter variable. This error causes a NPE in line 217.