### PR TITLE
Choose correct DS based on class ID in FederatedStoreManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-core</artifactId>
-    <version>4.1.7</version>
+    <version>4.1.7-mc1</version>
 
     <name>DataNucleus Core</name>
     <description>

--- a/src/main/java/org/datanucleus/store/federation/FederatedStoreManager.java
+++ b/src/main/java/org/datanucleus/store/federation/FederatedStoreManager.java
@@ -35,6 +35,7 @@ import org.datanucleus.PropertyNames;
 import org.datanucleus.api.ApiAdapter;
 import org.datanucleus.exceptions.NucleusUserException;
 import org.datanucleus.flush.FlushProcess;
+import org.datanucleus.identity.SingleFieldId;
 import org.datanucleus.metadata.AbstractClassMetaData;
 import org.datanucleus.metadata.AbstractMemberMetaData;
 import org.datanucleus.metadata.MetaDataManager;
@@ -332,7 +333,10 @@ public class FederatedStoreManager implements StoreManager
     {
         NucleusLogger.PERSISTENCE.debug(">> TODO Need to allocate manageClassForIdentity(" + id + ") to correct store manager");
         // TODO Work out if this class is in this store manager
-        return primaryStoreMgr.manageClassForIdentity(id, clr);
+		if(id instanceof SingleFieldId){
+			return  getStoreManagerForClass(((SingleFieldId)id).getTargetClassName(), clr).manageClassForIdentity(id, clr);
+		}
+		return primaryStoreMgr.manageClassForIdentity(id, clr);
     }
 
     public boolean managesClass(String className)


### PR DESCRIPTION
Hi,

this change allows us to use the FederatedStoreManager in Apache Isis (http://isis.apache.org) for the `SingleFieldId` case.

This is probably a very naive approach, and we have seen that there are additional TODO comments in that file.

If you could point us at additional things which we should take care of, we can provide a better patch.

Thank you

Kambiz
