### PR TITLE
[NUCCORE] support level-2 distributed cache in Hive Metastore

### DIFF
--- a/src/main/java/org/datanucleus/enhancer/EnhancementHelper.java
+++ b/src/main/java/org/datanucleus/enhancer/EnhancementHelper.java
@@ -156,9 +156,27 @@ public class EnhancementHelper extends java.lang.Object
      */
     public Persistable newInstance(Class pcClass, StateManager sm)
     {
+        // check whether pcClass has been loaded
+        checkClassLoad(pcClass);
+        
         Meta meta = getMeta(pcClass);
         Persistable pcInstance = meta.getPC();
         return pcInstance == null ? null : pcInstance.dnNewInstance(sm);
+    }
+    
+    private void checkClassLoad(Class pcClass) 
+    {
+        if (registeredClasses.get(pcClass) == null) 
+        {
+            try 
+            {
+                Class.forName(pcClass.getName());
+            } 
+            catch (ClassNotFoundException e) 
+            {
+                throw new NucleusUserException("Cannot lookup meta Class for " + pcClass + " - nothing found");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
When I use Ehcache as Level-2 cache in Hive Metastore to meet distributed cache need using Terracotta server, I found that Datanucleus core component does not support distributed situation. That is to say, the exception named 'Cannot lookup meta info for class xxx - nothing found' is threw out at the startup of second Hive Metastore service. The reason I found is that Datanucleus fetches Class object from distributed cache through Ehcache and get its metadata directly which is not loaded and registered locally in the second Hive Metastore.

This patch is a simple solution in this case but I don't know whether it's good enough (there are several newInstance functions indeed).