### PR TITLE
added initial .travis.yml and cobertura coverage check for codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+# specifying other dists doesn't make sense because `trusty` doesn't have `oraclejdk8` (fails due to `Sorry, but JDK '[oraclejdk8]' is not known.`) which is the only supported JDK currently. Testing on Mac OSX doesn't make too much sense since it will run the same `maven` based build routine.
+
+jdk:
+- oraclejdk8
+- openjdk8
+    # Java 7 isn't supported in 3.x
+
+install: /bin/true
+
+script:
+- mvn --batch-mode install
+    # separating build and tests into separate commands causes `Failed to execute goal org.apache.rat:apache-rat-plugin:0.11:check (default) on project openjpa-lib: Cannot read header: src/main/java/org/apache/openjpa/lib/ant/AbstractTask.java (No such file or directory)`
+- mvn cobertura:cobertura
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,18 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <formats>
+                        <format>html</format>
+                        <format>xml</format>
+                    </formats>
+                    <check />
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
https://github.com/datanucleus/datanucleus-jpa-query/issues/4 and https://github.com/datanucleus/datanucleus-jpa-query/issues/5 made me wonder about the test coverage of DataNucleus, so created this to check in a reproducible way which can be integrated into the development workflow without overhead.

The [coverage showed < 4%](https://codecov.io/gh/krichter722/datanucleus-core/commits) which - in case that's true - is very low.

It should be trivial to adapt `.travis.yml` to other DataNucleus projects.