### PR TITLE
Undo setting 'beginTime' in 'internalPostCommit'

### DIFF
--- a/src/main/java/org/datanucleus/TransactionImpl.java
+++ b/src/main/java/org/datanucleus/TransactionImpl.java
@@ -555,7 +555,6 @@ public class TransactionImpl implements Transaction
     {
         try
         {
-            beginTime = -1;
             active = false;
             if (ec.getStatistics() != null)
             {


### PR DESCRIPTION
The statistics are messed up because AbstractStatistics#transactionCommitted is called with the current unix timestamp instead of the execution time of the transaction.

This is caused by the fact that 'beginTime' is set to -1 in 'internalPostCommit'. I think this is an oversight, because that doesn't make any sense since it's already set in 'internalBegin'.