### PR TITLE
Support of the Java 11 bytecode generating by enhancer. 

### DIFF
--- a/src/main/java/org/datanucleus/enhancer/asm/ClassReader.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ClassReader.java
@@ -161,7 +161,7 @@ public class ClassReader {
     this.b = classFileBuffer;
     // Check the class' major_version. This field is after the magic and minor_version fields, which
     // use 4 and 2 bytes respectively.
-    if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V10) {
+    if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V11) {
       throw new IllegalArgumentException(
           "Unsupported class file major version " + readShort(classFileOffset + 6));
     }

--- a/src/main/java/org/datanucleus/enhancer/asm/Opcodes.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Opcodes.java
@@ -59,6 +59,7 @@ public interface Opcodes {
   int V1_8 = 0 << 16 | 52;
   int V9 = 0 << 16 | 53;
   int V10 = 0 << 16 | 54;
+  int V11 = 0 << 16 | 55;
 
   // Access flags values, defined in
   // - https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.1-200-E.1


### PR DESCRIPTION
Hello.
We have a project (test automation framework) that uses datanucleus to interact with data base (Oracle, interaction with MongoDb is coming soon). It is necessary to migrate the project to Java 11. 

And now we are facing the issue. Enhancer stopped working. An attempt to generate/enhance classes throws the error:

```
SEVERE: Error thrown enhancing with ASMClassEnhancer
java.lang.IllegalArgumentException: Unsupported class file major version 55
	at org.datanucleus.enhancer.asm.ClassReader.<init>(ClassReader.java:166)
	at org.datanucleus.enhancer.asm.ClassReader.<init>(ClassReader.java:148)
	at org.datanucleus.enhancer.asm.ClassReader.<init>(ClassReader.java:136)
	at org.datanucleus.enhancer.asm.ClassReader.<init>(ClassReader.java:237)
	at org.datanucleus.enhancer.ClassEnhancerImpl.enhance(ClassEnhancerImpl.java:694)
	at org.datanucleus.enhancer.DataNucleusEnhancer.enhanceClass(DataNucleusEnhancer.java:937)
	at org.datanucleus.enhancer.DataNucleusEnhancer.enhance(DataNucleusEnhancer.java:528)
	...
``` 

Proposed change is supposed to fix out this issue and help other teams that face up the same issue.