### PR TITLE
Upgrade repackaged ASM to v7.0

### DIFF
--- a/src/main/java/org/datanucleus/enhancer/ClassEnhancer.java
+++ b/src/main/java/org/datanucleus/enhancer/ClassEnhancer.java
@@ -32,7 +32,7 @@ import org.datanucleus.metadata.MetaDataManager;
 public interface ClassEnhancer
 {
     /** Version of the ASM API to use (introduced in ASM v4 to aid backward compatibility). */
-    public static final int ASM_API_VERSION = Opcodes.ASM5;
+    public static final int ASM_API_VERSION = Opcodes.ASM7;
 
     /** Option for generating the default constructor. */
     public static final String OPTION_GENERATE_DEFAULT_CONSTRUCTOR = "generate-default-constructor";

--- a/src/main/java/org/datanucleus/enhancer/asm/AnnotationVisitor.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/AnnotationVisitor.java
@@ -39,7 +39,7 @@ public abstract class AnnotationVisitor {
 
   /**
    * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   protected final int api;
 
@@ -50,8 +50,7 @@ public abstract class AnnotationVisitor {
    * Constructs a new {@link AnnotationVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   public AnnotationVisitor(final int api) {
     this(api, null);
@@ -61,16 +60,12 @@ public abstract class AnnotationVisitor {
    * Constructs a new {@link AnnotationVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    * @param annotationVisitor the annotation visitor to which this visitor must delegate method
    *     calls. May be null.
    */
   public AnnotationVisitor(final int api, final AnnotationVisitor annotationVisitor) {
-    if (api != Opcodes.ASM6
-        && api != Opcodes.ASM5
-        && api != Opcodes.ASM4
-        && api != Opcodes.ASM7_EXPERIMENTAL) {
+    if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
       throw new IllegalArgumentException();
     }
     this.api = api;

--- a/src/main/java/org/datanucleus/enhancer/asm/AnnotationWriter.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/AnnotationWriter.java
@@ -112,7 +112,7 @@ final class AnnotationWriter extends AnnotationVisitor {
       final boolean useNamedValues,
       final ByteVector annotation,
       final AnnotationWriter previousAnnotation) {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
     this.symbolTable = symbolTable;
     this.useNamedValues = useNamedValues;
     this.annotation = annotation;

--- a/src/main/java/org/datanucleus/enhancer/asm/ByteVector.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ByteVector.java
@@ -239,6 +239,7 @@ public class ByteVector {
    * @param stringValue a String whose UTF8 encoded length must be less than 65536.
    * @return this byte vector.
    */
+  // DontCheck(AbbreviationAsWordInName): can't be renamed (for backward binary compatibility).
   public ByteVector putUTF8(final String stringValue) {
     int charLength = stringValue.length();
     if (charLength > 65535) {
@@ -261,7 +262,7 @@ public class ByteVector {
         currentData[currentLength++] = (byte) charValue;
       } else {
         length = currentLength;
-        return encodeUTF8(stringValue, i, 65535);
+        return encodeUtf8(stringValue, i, 65535);
       }
     }
     length = currentLength;
@@ -280,14 +281,14 @@ public class ByteVector {
    *     encoded characters.
    * @return this byte vector.
    */
-  final ByteVector encodeUTF8(final String stringValue, final int offset, final int maxByteLength) {
+  final ByteVector encodeUtf8(final String stringValue, final int offset, final int maxByteLength) {
     int charLength = stringValue.length();
     int byteLength = offset;
     for (int i = offset; i < charLength; ++i) {
       char charValue = stringValue.charAt(i);
-      if (charValue >= '\u0001' && charValue <= '\u007F') {
+      if (charValue >= 0x0001 && charValue <= 0x007F) {
         byteLength++;
-      } else if (charValue <= '\u07FF') {
+      } else if (charValue <= 0x07FF) {
         byteLength += 2;
       } else {
         byteLength += 3;
@@ -308,9 +309,9 @@ public class ByteVector {
     int currentLength = length;
     for (int i = offset; i < charLength; ++i) {
       char charValue = stringValue.charAt(i);
-      if (charValue >= '\u0001' && charValue <= '\u007F') {
+      if (charValue >= 0x0001 && charValue <= 0x007F) {
         data[currentLength++] = (byte) charValue;
-      } else if (charValue <= '\u07FF') {
+      } else if (charValue <= 0x07FF) {
         data[currentLength++] = (byte) (0xC0 | charValue >> 6 & 0x1F);
         data[currentLength++] = (byte) (0x80 | charValue & 0x3F);
       } else {

--- a/src/main/java/org/datanucleus/enhancer/asm/ClassReader.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ClassReader.java
@@ -99,6 +99,7 @@ public class ClassReader {
    * necessarily start at offset 0. Use {@link #getItem} and {@link #header} to get correct
    * ClassFile element offsets within this byte array.
    */
+  // DontCheck(MemberName): can't be renamed (for backward binary compatibility).
   public final byte[] b;
 
   /**
@@ -109,11 +110,16 @@ public class ClassReader {
   private final int[] cpInfoOffsets;
 
   /**
-   * The value of each cp_info entry of the ClassFile's constant_pool array, <i>for Constant_Utf8
-   * and Constant_Dynamic constants only</i>. The value of constant pool entry i is given by
-   * cpInfoValues[i]. This cache avoids multiple parsing of those constant pool items.
+   * The String objects corresponding to the CONSTANT_Utf8 constant pool items. This cache avoids
+   * multiple parsing of a given CONSTANT_Utf8 constant pool item.
    */
-  private final Object[] cpInfoValues;
+  private final String[] constantUtf8Values;
+
+  /**
+   * The ConstantDynamic objects corresponding to the CONSTANT_Dynamic constant pool items. This
+   * cache avoids multiple parsing of a given CONSTANT_Dynamic constant pool item.
+   */
+  private final ConstantDynamic[] constantDynamicValues;
 
   /**
    * The start offsets in {@link #b} of each element of the bootstrap_methods array (in the
@@ -154,7 +160,9 @@ public class ClassReader {
    * @param classFileLength the length in bytes of the ClassFile to be read.
    */
   public ClassReader(
-      final byte[] classFileBuffer, final int classFileOffset, final int classFileLength) {
+      final byte[] classFileBuffer,
+      final int classFileOffset,
+      final int classFileLength) { // NOPMD(UnusedFormalParameter) used for backward compatibility.
     this(classFileBuffer, classFileOffset, /* checkClassVersion = */ true);
   }
 
@@ -168,7 +176,7 @@ public class ClassReader {
    */
   ClassReader(
       final byte[] classFileBuffer, final int classFileOffset, final boolean checkClassVersion) {
-    this.b = classFileBuffer;
+    b = classFileBuffer;
     // Check the class' major_version. This field is after the magic and minor_version fields, which
     // use 4 and 2 bytes respectively.
     if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V12) {
@@ -179,7 +187,7 @@ public class ClassReader {
     // minor_version and major_version fields, which use 4, 2 and 2 bytes respectively.
     int constantPoolCount = readUnsignedShort(classFileOffset + 8);
     cpInfoOffsets = new int[constantPoolCount];
-    cpInfoValues = new Object[constantPoolCount];
+    constantUtf8Values = new String[constantPoolCount];
     // Compute the offset of each constant pool entry, as well as a conservative estimate of the
     // maximum length of the constant pool strings. The first constant pool entry is after the
     // magic, minor_version, major_version and constant_pool_count fields, which use 4, 2, 2 and 2
@@ -187,6 +195,8 @@ public class ClassReader {
     int currentCpInfoIndex = 1;
     int currentCpInfoOffset = classFileOffset + 10;
     int currentMaxStringLength = 0;
+    boolean hasConstantDynamic = false;
+    boolean hasConstantInvokeDynamic = false;
     // The offset of the other entries depend on the total size of all the previous entries.
     while (currentCpInfoIndex < constantPoolCount) {
       cpInfoOffsets[currentCpInfoIndex++] = currentCpInfoOffset + 1;
@@ -198,9 +208,15 @@ public class ClassReader {
         case Symbol.CONSTANT_INTEGER_TAG:
         case Symbol.CONSTANT_FLOAT_TAG:
         case Symbol.CONSTANT_NAME_AND_TYPE_TAG:
-        case Symbol.CONSTANT_INVOKE_DYNAMIC_TAG:
+          cpInfoSize = 5;
+          break;
         case Symbol.CONSTANT_DYNAMIC_TAG:
           cpInfoSize = 5;
+          hasConstantDynamic = true;
+          break;
+        case Symbol.CONSTANT_INVOKE_DYNAMIC_TAG:
+          cpInfoSize = 5;
+          hasConstantInvokeDynamic = true;
           break;
         case Symbol.CONSTANT_LONG_TAG:
         case Symbol.CONSTANT_DOUBLE_TAG:
@@ -231,34 +247,18 @@ public class ClassReader {
       }
       currentCpInfoOffset += cpInfoSize;
     }
-    this.maxStringLength = currentMaxStringLength;
+    maxStringLength = currentMaxStringLength;
     // The Classfile's access_flags field is just after the last constant pool entry.
-    this.header = currentCpInfoOffset;
+    header = currentCpInfoOffset;
+
+    // Allocate the cache of ConstantDynamic values, if there is at least one.
+    constantDynamicValues = hasConstantDynamic ? new ConstantDynamic[constantPoolCount] : null;
 
     // Read the BootstrapMethods attribute, if any (only get the offset of each method).
-    int currentAttributeOffset = getFirstAttributeOffset();
-    int[] currentBootstrapMethodOffsets = null;
-    for (int i = readUnsignedShort(currentAttributeOffset - 2); i > 0; --i) {
-      // Read the attribute_info's attribute_name and attribute_length fields.
-      String attributeName = readUTF8(currentAttributeOffset, new char[maxStringLength]);
-      int attributeLength = readInt(currentAttributeOffset + 2);
-      currentAttributeOffset += 6;
-      if (Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
-        // Read the num_bootstrap_methods field and create an array of this size.
-        currentBootstrapMethodOffsets = new int[readUnsignedShort(currentAttributeOffset)];
-        // Compute and store the offset of each 'bootstrap_methods' array field entry.
-        int currentBootstrapMethodOffset = currentAttributeOffset + 2;
-        for (int j = 0; j < currentBootstrapMethodOffsets.length; ++j) {
-          currentBootstrapMethodOffsets[j] = currentBootstrapMethodOffset;
-          // Skip the bootstrap_method_ref and num_bootstrap_arguments fields (2 bytes each),
-          // as well as the bootstrap_arguments array field (of size num_bootstrap_arguments * 2).
-          currentBootstrapMethodOffset +=
-              4 + readUnsignedShort(currentBootstrapMethodOffset + 2) * 2;
-        }
-      }
-      currentAttributeOffset += attributeLength;
-    }
-    this.bootstrapMethodOffsets = currentBootstrapMethodOffsets;
+    bootstrapMethodOffsets =
+        (hasConstantDynamic | hasConstantInvokeDynamic)
+            ? readBootstrapMethodsAttribute(currentMaxStringLength)
+            : null;
   }
 
   /**
@@ -491,7 +491,7 @@ public class ClassReader {
         accessFlags |= Opcodes.ACC_SYNTHETIC;
       } else if (Constants.SOURCE_DEBUG_EXTENSION.equals(attributeName)) {
         sourceDebugExtension =
-            readUTF(currentAttributeOffset, attributeLength, new char[attributeLength]);
+            readUtf(currentAttributeOffset, attributeLength, new char[attributeLength]);
       } else if (Constants.RUNTIME_INVISIBLE_ANNOTATIONS.equals(attributeName)) {
         runtimeInvisibleAnnotationsOffset = currentAttributeOffset;
       } else if (Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
@@ -502,9 +502,8 @@ public class ClassReader {
         moduleMainClass = readClass(currentAttributeOffset, charBuffer);
       } else if (Constants.MODULE_PACKAGES.equals(attributeName)) {
         modulePackagesOffset = currentAttributeOffset;
-      } else if (Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
-        // This attribute is read in the constructor.
-      } else {
+      } else if (!Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
+        // The BootstrapMethods attribute is read in the constructor.
         Attribute attribute =
             readAttribute(
                 attributePrototypes,
@@ -533,12 +532,13 @@ public class ClassReader {
 
     // Visit the Module, ModulePackages and ModuleMainClass attributes.
     if (moduleOffset != 0) {
-      readModule(classVisitor, context, moduleOffset, modulePackagesOffset, moduleMainClass);
+      readModuleAttributes(
+          classVisitor, context, moduleOffset, modulePackagesOffset, moduleMainClass);
     }
 
     // Visit the NestHost attribute.
     if (nestHostClass != null) {
-      classVisitor.visitNestHostExperimental(nestHostClass);
+      classVisitor.visitNestHost(nestHostClass);
     }
 
     // Visit the EnclosingMethod attribute.
@@ -648,7 +648,7 @@ public class ClassReader {
       int numberOfNestMembers = readUnsignedShort(nestMembersOffset);
       int currentNestMemberOffset = nestMembersOffset + 2;
       while (numberOfNestMembers-- > 0) {
-        classVisitor.visitNestMemberExperimental(readClass(currentNestMemberOffset, charBuffer));
+        classVisitor.visitNestMember(readClass(currentNestMemberOffset, charBuffer));
         currentNestMemberOffset += 2;
       }
     }
@@ -688,7 +688,7 @@ public class ClassReader {
   // ----------------------------------------------------------------------------------------------
 
   /**
-   * Reads the module attribute and visit it.
+   * Reads the Module, ModulePackages and ModuleMainClass attributes and visit them.
    *
    * @param classVisitor the current class visitor
    * @param context information about the class being parsed.
@@ -698,7 +698,7 @@ public class ClassReader {
    *     attribute_info's attribute_name_index and attribute_length fields), or 0.
    * @param moduleMainClass the string corresponding to the ModuleMainClass attribute, or null.
    */
-  private void readModule(
+  private void readModuleAttributes(
       final ClassVisitor classVisitor,
       final Context context,
       final int moduleOffset,
@@ -1114,7 +1114,7 @@ public class ClassReader {
             context.currentMethodAccessFlags,
             context.currentMethodName,
             context.currentMethodDescriptor,
-            signatureIndex == 0 ? null : readUTF(signatureIndex, charBuffer),
+            signatureIndex == 0 ? null : readUtf(signatureIndex, charBuffer),
             exceptions);
     if (methodVisitor == null) {
       return currentOffset;
@@ -1604,18 +1604,15 @@ public class ClassReader {
 
     // Read the 'exception_table_length' and 'exception_table' field to create a label for each
     // referenced instruction, and to make methodVisitor visit the corresponding try catch blocks.
-    {
-      int exceptionTableLength = readUnsignedShort(currentOffset);
-      currentOffset += 2;
-      while (exceptionTableLength-- > 0) {
-        Label start = createLabel(readUnsignedShort(currentOffset), labels);
-        Label end = createLabel(readUnsignedShort(currentOffset + 2), labels);
-        Label handler = createLabel(readUnsignedShort(currentOffset + 4), labels);
-        String catchType =
-            readUTF8(cpInfoOffsets[readUnsignedShort(currentOffset + 6)], charBuffer);
-        currentOffset += 8;
-        methodVisitor.visitTryCatchBlock(start, end, handler, catchType);
-      }
+    int exceptionTableLength = readUnsignedShort(currentOffset);
+    currentOffset += 2;
+    while (exceptionTableLength-- > 0) {
+      Label start = createLabel(readUnsignedShort(currentOffset), labels);
+      Label end = createLabel(readUnsignedShort(currentOffset + 2), labels);
+      Label handler = createLabel(readUnsignedShort(currentOffset + 4), labels);
+      String catchType = readUTF8(cpInfoOffsets[readUnsignedShort(currentOffset + 6)], charBuffer);
+      currentOffset += 8;
+      methodVisitor.visitTryCatchBlock(start, end, handler, catchType);
     }
 
     // Read the Code attributes to create a label for each referenced instruction (the variables
@@ -2145,11 +2142,11 @@ public class ClassReader {
             currentOffset += 4 - (currentBytecodeOffset & 3);
             // Read the instruction.
             Label defaultLabel = labels[currentBytecodeOffset + readInt(currentOffset)];
-            int nPairs = readInt(currentOffset + 4);
+            int numPairs = readInt(currentOffset + 4);
             currentOffset += 8;
-            int[] keys = new int[nPairs];
-            Label[] values = new Label[nPairs];
-            for (int i = 0; i < nPairs; ++i) {
+            int[] keys = new int[numPairs];
+            Label[] values = new Label[numPairs];
+            for (int i = 0; i < numPairs; ++i) {
               keys[i] = readInt(currentOffset);
               values[i] = labels[currentBytecodeOffset + readInt(currentOffset + 4)];
               currentOffset += 8;
@@ -2362,12 +2359,12 @@ public class ClassReader {
 
     // Visit the local variable type annotations of the RuntimeVisibleTypeAnnotations attribute.
     if (visibleTypeAnnotationOffsets != null) {
-      for (int i = 0; i < visibleTypeAnnotationOffsets.length; ++i) {
-        int targetType = readByte(visibleTypeAnnotationOffsets[i]);
+      for (int typeAnnotationOffset : visibleTypeAnnotationOffsets) {
+        int targetType = readByte(typeAnnotationOffset);
         if (targetType == TypeReference.LOCAL_VARIABLE
             || targetType == TypeReference.RESOURCE_VARIABLE) {
           // Parse the target_type, target_info and target_path fields.
-          currentOffset = readTypeAnnotationTarget(context, visibleTypeAnnotationOffsets[i]);
+          currentOffset = readTypeAnnotationTarget(context, typeAnnotationOffset);
           // Parse the type_index field.
           String annotationDescriptor = readUTF8(currentOffset, charBuffer);
           currentOffset += 2;
@@ -2390,12 +2387,12 @@ public class ClassReader {
 
     // Visit the local variable type annotations of the RuntimeInvisibleTypeAnnotations attribute.
     if (invisibleTypeAnnotationOffsets != null) {
-      for (int i = 0; i < invisibleTypeAnnotationOffsets.length; ++i) {
-        int targetType = readByte(invisibleTypeAnnotationOffsets[i]);
+      for (int typeAnnotationOffset : invisibleTypeAnnotationOffsets) {
+        int targetType = readByte(typeAnnotationOffset);
         if (targetType == TypeReference.LOCAL_VARIABLE
             || targetType == TypeReference.RESOURCE_VARIABLE) {
           // Parse the target_type, target_info and target_path fields.
-          currentOffset = readTypeAnnotationTarget(context, invisibleTypeAnnotationOffsets[i]);
+          currentOffset = readTypeAnnotationTarget(context, typeAnnotationOffset);
           // Parse the type_index field.
           String annotationDescriptor = readUTF8(currentOffset, charBuffer);
           currentOffset += 2;
@@ -2961,12 +2958,12 @@ public class ClassReader {
   private void computeImplicitFrame(final Context context) {
     String methodDescriptor = context.currentMethodDescriptor;
     Object[] locals = context.currentFrameLocalTypes;
-    int nLocal = 0;
+    int numLocal = 0;
     if ((context.currentMethodAccessFlags & Opcodes.ACC_STATIC) == 0) {
       if ("<init>".equals(context.currentMethodName)) {
-        locals[nLocal++] = Opcodes.UNINITIALIZED_THIS;
+        locals[numLocal++] = Opcodes.UNINITIALIZED_THIS;
       } else {
-        locals[nLocal++] = readClass(header + 2, context.charBuffer);
+        locals[numLocal++] = readClass(header + 2, context.charBuffer);
       }
     }
     // Parse the method descriptor, one argument type descriptor at each iteration. Start by
@@ -2980,16 +2977,16 @@ public class ClassReader {
         case 'B':
         case 'S':
         case 'I':
-          locals[nLocal++] = Opcodes.INTEGER;
+          locals[numLocal++] = Opcodes.INTEGER;
           break;
         case 'F':
-          locals[nLocal++] = Opcodes.FLOAT;
+          locals[numLocal++] = Opcodes.FLOAT;
           break;
         case 'J':
-          locals[nLocal++] = Opcodes.LONG;
+          locals[numLocal++] = Opcodes.LONG;
           break;
         case 'D':
-          locals[nLocal++] = Opcodes.DOUBLE;
+          locals[numLocal++] = Opcodes.DOUBLE;
           break;
         case '[':
           while (methodDescriptor.charAt(currentMethodDescritorOffset) == '[') {
@@ -3001,7 +2998,7 @@ public class ClassReader {
               ++currentMethodDescritorOffset;
             }
           }
-          locals[nLocal++] =
+          locals[numLocal++] =
               methodDescriptor.substring(
                   currentArgumentDescriptorStartOffset, ++currentMethodDescritorOffset);
           break;
@@ -3009,12 +3006,12 @@ public class ClassReader {
           while (methodDescriptor.charAt(currentMethodDescritorOffset) != ';') {
             ++currentMethodDescritorOffset;
           }
-          locals[nLocal++] =
+          locals[numLocal++] =
               methodDescriptor.substring(
                   currentArgumentDescriptorStartOffset + 1, currentMethodDescritorOffset++);
           break;
         default:
-          context.currentFrameLocalCount = nLocal;
+          context.currentFrameLocalCount = numLocal;
           return;
       }
     }
@@ -3181,7 +3178,11 @@ public class ClassReader {
   // Methods to parse attributes
   // ----------------------------------------------------------------------------------------------
 
-  /** @return the offset in {@link #b} of the first ClassFile's 'attributes' array field entry. */
+  /**
+   * Returns the offset in {@link #b} of the first ClassFile's 'attributes' array field entry.
+   *
+   * @return the offset in {@link #b} of the first ClassFile's 'attributes' array field entry.
+   */
   final int getFirstAttributeOffset() {
     // Skip the access_flags, this_class, super_class, and interfaces_count fields (using 2 bytes
     // each), as well as the interfaces array field (2 bytes per interface).
@@ -3223,6 +3224,41 @@ public class ClassReader {
   }
 
   /**
+   * Reads the BootstrapMethods attribute to compute the offset of each bootstrap method.
+   *
+   * @param maxStringLength a conservative estimate of the maximum length of the strings contained
+   *     in the constant pool of the class.
+   * @return the offsets of the bootstrap methods or null.
+   */
+  private int[] readBootstrapMethodsAttribute(final int maxStringLength) {
+    char[] charBuffer = new char[maxStringLength];
+    int currentAttributeOffset = getFirstAttributeOffset();
+    int[] currentBootstrapMethodOffsets = null;
+    for (int i = readUnsignedShort(currentAttributeOffset - 2); i > 0; --i) {
+      // Read the attribute_info's attribute_name and attribute_length fields.
+      String attributeName = readUTF8(currentAttributeOffset, charBuffer);
+      int attributeLength = readInt(currentAttributeOffset + 2);
+      currentAttributeOffset += 6;
+      if (Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
+        // Read the num_bootstrap_methods field and create an array of this size.
+        currentBootstrapMethodOffsets = new int[readUnsignedShort(currentAttributeOffset)];
+        // Compute and store the offset of each 'bootstrap_methods' array field entry.
+        int currentBootstrapMethodOffset = currentAttributeOffset + 2;
+        for (int j = 0; j < currentBootstrapMethodOffsets.length; ++j) {
+          currentBootstrapMethodOffsets[j] = currentBootstrapMethodOffset;
+          // Skip the bootstrap_method_ref and num_bootstrap_arguments fields (2 bytes each),
+          // as well as the bootstrap_arguments array field (of size num_bootstrap_arguments * 2).
+          currentBootstrapMethodOffset +=
+              4 + readUnsignedShort(currentBootstrapMethodOffset + 2) * 2;
+        }
+        return currentBootstrapMethodOffsets;
+      }
+      currentAttributeOffset += attributeLength;
+    }
+    return null;
+  }
+
+  /**
    * Reads a non standard JVMS 'attribute' structure in {@link #b}.
    *
    * @param attributePrototypes prototypes of the attributes that must be parsed during the visit of
@@ -3236,8 +3272,8 @@ public class ClassReader {
    * @param codeAttributeOffset the start offset of the enclosing Code attribute in {@link #b}, or
    *     -1 if the attribute to be read is not a code attribute. The 6 attribute header bytes
    *     (attribute_name_index and attribute_length) are not taken into account here.
-   * @param labels the labels of the method's code, or <tt>null</tt> if the attribute to be read is
-   *     not a code attribute.
+   * @param labels the labels of the method's code, or <tt>null</tt> if the attribute to be read
+   *     is not a code attribute.
    * @return the attribute that has been read.
    */
   private Attribute readAttribute(
@@ -3248,9 +3284,9 @@ public class ClassReader {
       final char[] charBuffer,
       final int codeAttributeOffset,
       final Label[] labels) {
-    for (int i = 0; i < attributePrototypes.length; ++i) {
-      if (attributePrototypes[i].type.equals(type)) {
-        return attributePrototypes[i].read(
+    for (Attribute attributePrototype : attributePrototypes) {
+      if (attributePrototype.type.equals(type)) {
+        return attributePrototype.read(
             this, offset, length, charBuffer, codeAttributeOffset, labels);
       }
     }
@@ -3367,12 +3403,13 @@ public class ClassReader {
    *     large. It is not automatically resized.
    * @return the String corresponding to the specified CONSTANT_Utf8 entry.
    */
+  // DontCheck(AbbreviationAsWordInName): can't be renamed (for backward binary compatibility).
   public String readUTF8(final int offset, final char[] charBuffer) {
     int constantPoolEntryIndex = readUnsignedShort(offset);
     if (offset == 0 || constantPoolEntryIndex == 0) {
       return null;
     }
-    return readUTF(constantPoolEntryIndex, charBuffer);
+    return readUtf(constantPoolEntryIndex, charBuffer);
   }
 
   /**
@@ -3384,15 +3421,14 @@ public class ClassReader {
    *     large. It is not automatically resized.
    * @return the String corresponding to the specified CONSTANT_Utf8 entry.
    */
-  final String readUTF(final int constantPoolEntryIndex, final char[] charBuffer) {
-    String value = (String) cpInfoValues[constantPoolEntryIndex];
+  final String readUtf(final int constantPoolEntryIndex, final char[] charBuffer) {
+    String value = constantUtf8Values[constantPoolEntryIndex];
     if (value != null) {
       return value;
     }
     int cpInfoOffset = cpInfoOffsets[constantPoolEntryIndex];
-    value = readUTF(cpInfoOffset + 2, readUnsignedShort(cpInfoOffset), charBuffer);
-    cpInfoValues[constantPoolEntryIndex] = value;
-    return value;
+    return constantUtf8Values[constantPoolEntryIndex] =
+        readUtf(cpInfoOffset + 2, readUnsignedShort(cpInfoOffset), charBuffer);
   }
 
   /**
@@ -3404,7 +3440,7 @@ public class ClassReader {
    *     large. It is not automatically resized.
    * @return the String corresponding to the specified UTF8 string.
    */
-  private String readUTF(final int utfOffset, final int utfLength, final char[] charBuffer) {
+  private String readUtf(final int utfOffset, final int utfLength, final char[] charBuffer) {
     int currentOffset = utfOffset;
     int endOffset = currentOffset + utfLength;
     int strLength = 0;
@@ -3498,7 +3534,7 @@ public class ClassReader {
    */
   private ConstantDynamic readConstantDynamic(
       final int constantPoolEntryIndex, final char[] charBuffer) {
-    ConstantDynamic constantDynamic = (ConstantDynamic) cpInfoValues[constantPoolEntryIndex];
+    ConstantDynamic constantDynamic = constantDynamicValues[constantPoolEntryIndex];
     if (constantDynamic != null) {
       return constantDynamic;
     }
@@ -3514,9 +3550,8 @@ public class ClassReader {
       bootstrapMethodArguments[i] = readConst(readUnsignedShort(bootstrapMethodOffset), charBuffer);
       bootstrapMethodOffset += 2;
     }
-    constantDynamic = new ConstantDynamic(name, descriptor, handle, bootstrapMethodArguments);
-    cpInfoValues[constantPoolEntryIndex] = constantDynamic;
-    return constantDynamic;
+    return constantDynamicValues[constantPoolEntryIndex] =
+        new ConstantDynamic(name, descriptor, handle, bootstrapMethodArguments);
   }
 
   /**

--- a/src/main/java/org/datanucleus/enhancer/asm/ClassTooLargeException.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ClassTooLargeException.java
@@ -34,8 +34,8 @@ package org.datanucleus.enhancer.asm;
  * @author Jason Zaugg
  */
 public final class ClassTooLargeException extends IndexOutOfBoundsException {
+  private static final long serialVersionUID = 160715609518896765L;
 
-  private static final long serialVersionUID = -1400659197475309264L;
   private final String className;
   private final int constantPoolCount;
 
@@ -51,12 +51,20 @@ public final class ClassTooLargeException extends IndexOutOfBoundsException {
     this.constantPoolCount = constantPoolCount;
   }
 
-  /** @return the internal name of the class. */
+  /**
+   * Returns the internal name of the class.
+   *
+   * @return the internal name of the class.
+   */
   public String getClassName() {
     return className;
   }
 
-  /** @return the number of constant pool items of the class. */
+  /**
+   * Returns the number of constant pool items of the class.
+   *
+   * @return the number of constant pool items of the class.
+   */
   public int getConstantPoolCount() {
     return constantPoolCount;
   }

--- a/src/main/java/org/datanucleus/enhancer/asm/ClassVisitor.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ClassVisitor.java
@@ -40,7 +40,7 @@ public abstract class ClassVisitor {
 
   /**
    * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   protected final int api;
 
@@ -51,8 +51,7 @@ public abstract class ClassVisitor {
    * Constructs a new {@link ClassVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   public ClassVisitor(final int api) {
     this(api, null);
@@ -62,16 +61,12 @@ public abstract class ClassVisitor {
    * Constructs a new {@link ClassVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    * @param classVisitor the class visitor to which this visitor must delegate method calls. May be
    *     null.
    */
   public ClassVisitor(final int api, final ClassVisitor classVisitor) {
-    if (api != Opcodes.ASM6
-        && api != Opcodes.ASM5
-        && api != Opcodes.ASM4
-        && api != Opcodes.ASM7_EXPERIMENTAL) {
+    if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
       throw new IllegalArgumentException();
     }
     this.api = api;
@@ -109,8 +104,8 @@ public abstract class ClassVisitor {
   /**
    * Visits the source of the class.
    *
-   * @param source the name of the source file from which the class was compiled. May be
-   *     <tt>null</tt>.
+   * @param source the name of the source file from which the class was compiled. May be {@literal
+   *     null}.
    * @param debug additional debug information to compute the correspondence between source and
    *     compiled elements of the class. May be <tt>null</tt>.
    */
@@ -132,7 +127,7 @@ public abstract class ClassVisitor {
    */
   public ModuleVisitor visitModule(final String name, final int access, final String version) {
     if (api < Opcodes.ASM6) {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException("This feature requires ASM6");
     }
     if (cv != null) {
       return cv.visitModule(name, access, version);
@@ -141,22 +136,21 @@ public abstract class ClassVisitor {
   }
 
   /**
-   * <b>Experimental, use at your own risk. This method will be renamed when it becomes stable, this
-   * will break existing code using it</b>. Visits the nest host class of the class. A nest is a set
-   * of classes of the same package that share access to their private members. One of these
-   * classes, called the host, lists the other members of the nest, which in turn should link to the
-   * host of their nest. This method must be called only once and only if the visited class is a
-   * non-host member of a nest. A class is implicitly its own nest, so it's invalid to call this
-   * method with the visited class name as argument.
+   * Visits the nest host class of the class. A nest is a set of classes of the same package that
+   * share access to their private members. One of these classes, called the host, lists the other
+   * members of the nest, which in turn should link to the host of their nest. This method must be
+   * called only once and only if the visited class is a non-host member of a nest. A class is
+   * implicitly its own nest, so it's invalid to call this method with the visited class name as
+   * argument.
    *
    * @param nestHost the internal name of the host class of the nest.
    */
-  public void visitNestHostExperimental(final String nestHost) {
-    if (api < Opcodes.ASM7_EXPERIMENTAL) {
-      throw new UnsupportedOperationException();
+  public void visitNestHost(final String nestHost) {
+    if (api < Opcodes.ASM7) {
+      throw new UnsupportedOperationException("This feature requires ASM7");
     }
     if (cv != null) {
-      cv.visitNestHostExperimental(nestHost);
+      cv.visitNestHost(nestHost);
     }
   }
 
@@ -209,7 +203,7 @@ public abstract class ClassVisitor {
   public AnnotationVisitor visitTypeAnnotation(
       final int typeRef, final TypePath typePath, final String descriptor, final boolean visible) {
     if (api < Opcodes.ASM5) {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException("This feature requires ASM5");
     }
     if (cv != null) {
       return cv.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
@@ -229,22 +223,20 @@ public abstract class ClassVisitor {
   }
 
   /**
-   * <b>Experimental, use at your own risk. This method will be renamed when it becomes stable, this
-   * will break existing code using it</b>. Visits a member of the nest. A nest is a set of classes
-   * of the same package that share access to their private members. One of these classes, called
-   * the host, lists the other members of the nest, which in turn should link to the host of their
-   * nest. This method must be called only if the visited class is the host of a nest. A nest host
-   * is implicitly a member of its own nest, so it's invalid to call this method with the visited
-   * class name as argument.
+   * Visits a member of the nest. A nest is a set of classes of the same package that share access
+   * to their private members. One of these classes, called the host, lists the other members of the
+   * nest, which in turn should link to the host of their nest. This method must be called only if
+   * the visited class is the host of a nest. A nest host is implicitly a member of its own nest, so
+   * it's invalid to call this method with the visited class name as argument.
    *
    * @param nestMember the internal name of a nest member.
    */
-  public void visitNestMemberExperimental(final String nestMember) {
-    if (api < Opcodes.ASM7_EXPERIMENTAL) {
-      throw new UnsupportedOperationException();
+  public void visitNestMember(final String nestMember) {
+    if (api < Opcodes.ASM7) {
+      throw new UnsupportedOperationException("This feature requires ASM7");
     }
     if (cv != null) {
-      cv.visitNestMemberExperimental(nestMember);
+      cv.visitNestMember(nestMember);
     }
   }
 

--- a/src/main/java/org/datanucleus/enhancer/asm/ConstantDynamic.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ConstantDynamic.java
@@ -99,14 +99,47 @@ public final class ConstantDynamic {
   }
 
   /**
-   * Returns the arguments to pass to the bootstrap method, in order to compute the value of this
+   * Returns the number of arguments passed to the bootstrap method, in order to compute the value
+   * of this constant.
+   *
+   * @return the number of arguments passed to the bootstrap method, in order to compute the value
+   *     of this constant.
+   */
+  public int getBootstrapMethodArgumentCount() {
+    return bootstrapMethodArguments.length;
+  }
+
+  /**
+   * Returns an argument passed to the bootstrap method, in order to compute the value of this
    * constant.
+   *
+   * @param index an argument index, between 0 and {@link #getBootstrapMethodArgumentCount()}
+   *     (exclusive).
+   * @return the argument passed to the bootstrap method, with the given index.
+   */
+  public Object getBootstrapMethodArgument(final int index) {
+    return bootstrapMethodArguments[index];
+  }
+
+  /**
+   * Returns the arguments to pass to the bootstrap method, in order to compute the value of this
+   * constant. WARNING: this array must not be modified, and must not be returned to the user.
    *
    * @return the arguments to pass to the bootstrap method, in order to compute the value of this
    *     constant.
    */
-  public Object[] getBootstrapMethodArguments() {
+  Object[] getBootstrapMethodArgumentsUnsafe() {
     return bootstrapMethodArguments;
+  }
+
+  /**
+   * Returns the size of this constant.
+   *
+   * @return the size of this constant, i.e., 2 for <tt>long</tt> and <tt>double</tt>, 1 otherwise.
+   */
+  public int getSize() {
+    char firstCharOfDescriptor = descriptor.charAt(0);
+    return (firstCharOfDescriptor == 'J' || firstCharOfDescriptor == 'D') ? 2 : 1;
   }
 
   @Override

--- a/src/main/java/org/datanucleus/enhancer/asm/Constants.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Constants.java
@@ -36,8 +36,6 @@ package org.datanucleus.enhancer.asm;
  */
 final class Constants implements Opcodes {
 
-  private Constants() {}
-
   // The ClassFile attribute names, in the order they are defined in
   // https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7-300.
 
@@ -174,4 +172,6 @@ final class Constants implements Opcodes {
   static final int ASM_IFNULL = IFNULL + ASM_IFNULL_OPCODE_DELTA;
   static final int ASM_IFNONNULL = IFNONNULL + ASM_IFNULL_OPCODE_DELTA;
   static final int ASM_GOTO_W = 220;
+
+  private Constants() {}
 }

--- a/src/main/java/org/datanucleus/enhancer/asm/FieldVisitor.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/FieldVisitor.java
@@ -38,7 +38,7 @@ public abstract class FieldVisitor {
 
   /**
    * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   protected final int api;
 
@@ -49,8 +49,7 @@ public abstract class FieldVisitor {
    * Constructs a new {@link FieldVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   public FieldVisitor(final int api) {
     this(api, null);
@@ -60,16 +59,12 @@ public abstract class FieldVisitor {
    * Constructs a new {@link FieldVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    * @param fieldVisitor the field visitor to which this visitor must delegate method calls. May be
    *     null.
    */
   public FieldVisitor(final int api, final FieldVisitor fieldVisitor) {
-    if (api != Opcodes.ASM6
-        && api != Opcodes.ASM5
-        && api != Opcodes.ASM4
-        && api != Opcodes.ASM7_EXPERIMENTAL) {
+    if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
       throw new IllegalArgumentException();
     }
     this.api = api;
@@ -107,7 +102,7 @@ public abstract class FieldVisitor {
   public AnnotationVisitor visitTypeAnnotation(
       final int typeRef, final TypePath typePath, final String descriptor, final boolean visible) {
     if (api < Opcodes.ASM5) {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException("This feature requires ASM5");
     }
     if (fv != null) {
       return fv.visitTypeAnnotation(typeRef, typePath, descriptor, visible);

--- a/src/main/java/org/datanucleus/enhancer/asm/FieldWriter.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/FieldWriter.java
@@ -124,7 +124,7 @@ final class FieldWriter extends FieldVisitor {
       final String descriptor,
       final String signature,
       final Object constantValue) {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
     this.symbolTable = symbolTable;
     this.accessFlags = access;
     this.nameIndex = symbolTable.addConstantUtf8(name);
@@ -151,10 +151,10 @@ final class FieldWriter extends FieldVisitor {
     if (visible) {
       return lastRuntimeVisibleAnnotation =
           new AnnotationWriter(symbolTable, annotation, lastRuntimeVisibleAnnotation);
+    } else {
+      return lastRuntimeInvisibleAnnotation =
+          new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
     }
-
-    return lastRuntimeInvisibleAnnotation =
-            new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
   }
 
   @Override
@@ -171,10 +171,10 @@ final class FieldWriter extends FieldVisitor {
     if (visible) {
       return lastRuntimeVisibleTypeAnnotation =
           new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeVisibleTypeAnnotation);
+    } else {
+      return lastRuntimeInvisibleTypeAnnotation =
+          new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeInvisibleTypeAnnotation);
     }
-
-    return lastRuntimeInvisibleTypeAnnotation =
-            new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeInvisibleTypeAnnotation);
   }
 
   @Override

--- a/src/main/java/org/datanucleus/enhancer/asm/Frame.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Frame.java
@@ -224,6 +224,38 @@ class Frame {
   private int[] initializations;
 
   // -----------------------------------------------------------------------------------------------
+  // Constructor
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Constructs a new Frame.
+   *
+   * @param owner the basic block to which these input and output stack map frames correspond.
+   */
+  Frame(final Label owner) {
+    this.owner = owner;
+  }
+
+  /**
+   * Sets this frame to the value of the given frame.
+   *
+   * <p>WARNING: after this method is called the two frames share the same data structures. It is
+   * recommended to discard the given frame to avoid unexpected side effects.
+   *
+   * @param frame The new frame value.
+   */
+  final void copyFrom(final Frame frame) {
+    inputLocals = frame.inputLocals;
+    inputStack = frame.inputStack;
+    outputStackStart = 0;
+    outputLocals = frame.outputLocals;
+    outputStack = frame.outputStack;
+    outputStackTop = frame.outputStackTop;
+    initializationCount = frame.initializationCount;
+    initializations = frame.initializations;
+  }
+
+  // -----------------------------------------------------------------------------------------------
   // Static methods to get abstract types from other type formats
   // -----------------------------------------------------------------------------------------------
 
@@ -337,38 +369,6 @@ class Frame {
   }
 
   // -----------------------------------------------------------------------------------------------
-  // Constructor
-  // -----------------------------------------------------------------------------------------------
-
-  /**
-   * Constructs a new Frame.
-   *
-   * @param owner the basic block to which these input and output stack map frames correspond.
-   */
-  Frame(final Label owner) {
-    this.owner = owner;
-  }
-
-  /**
-   * Sets this frame to the value of the given frame.
-   *
-   * <p>WARNING: after this method is called the two frames share the same data structures. It is
-   * recommended to discard the given frame to avoid unexpected side effects.
-   *
-   * @param frame The new frame value.
-   */
-  final void copyFrom(final Frame frame) {
-    inputLocals = frame.inputLocals;
-    inputStack = frame.inputStack;
-    outputStackStart = 0;
-    outputLocals = frame.outputLocals;
-    outputStack = frame.outputStack;
-    outputStackTop = frame.outputStackTop;
-    initializationCount = frame.initializationCount;
-    initializations = frame.initializations;
-  }
-
-  // -----------------------------------------------------------------------------------------------
   // Methods related to the input frame
   // -----------------------------------------------------------------------------------------------
 
@@ -415,21 +415,21 @@ class Frame {
    * Sets the input frame from the given public API frame description.
    *
    * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
-   * @param nLocal the number of local variables.
+   * @param numLocal the number of local variables.
    * @param local the local variable types, described using the same format as in {@link
    *     MethodVisitor#visitFrame}.
-   * @param nStack the number of operand stack elements.
+   * @param numStack the number of operand stack elements.
    * @param stack the operand stack types, described using the same format as in {@link
    *     MethodVisitor#visitFrame}.
    */
   final void setInputFrameFromApiFormat(
       final SymbolTable symbolTable,
-      final int nLocal,
+      final int numLocal,
       final Object[] local,
-      final int nStack,
+      final int numStack,
       final Object[] stack) {
     int inputLocalIndex = 0;
-    for (int i = 0; i < nLocal; ++i) {
+    for (int i = 0; i < numLocal; ++i) {
       inputLocals[inputLocalIndex++] = getAbstractTypeFromApiFormat(symbolTable, local[i]);
       if (local[i] == Opcodes.LONG || local[i] == Opcodes.DOUBLE) {
         inputLocals[inputLocalIndex++] = TOP;
@@ -438,15 +438,15 @@ class Frame {
     while (inputLocalIndex < inputLocals.length) {
       inputLocals[inputLocalIndex++] = TOP;
     }
-    int nStackTop = 0;
-    for (int i = 0; i < nStack; ++i) {
+    int numStackTop = 0;
+    for (int i = 0; i < numStack; ++i) {
       if (stack[i] == Opcodes.LONG || stack[i] == Opcodes.DOUBLE) {
-        ++nStackTop;
+        ++numStackTop;
       }
     }
-    inputStack = new int[nStack + nStackTop];
+    inputStack = new int[numStack + numStackTop];
     int inputStackIndex = 0;
-    for (int i = 0; i < nStack; ++i) {
+    for (int i = 0; i < numStack; ++i) {
       inputStack[inputStackIndex++] = getAbstractTypeFromApiFormat(symbolTable, stack[i]);
       if (stack[i] == Opcodes.LONG || stack[i] == Opcodes.DOUBLE) {
         inputStack[inputStackIndex++] = TOP;
@@ -475,15 +475,15 @@ class Frame {
       // If this local has never been assigned in this basic block, it is still equal to its value
       // in the input frame.
       return LOCAL_KIND | localIndex;
-    }
-
-    int abstractType = outputLocals[localIndex];
-    if (abstractType == 0) {
+    } else {
+      int abstractType = outputLocals[localIndex];
+      if (abstractType == 0) {
         // If this local has never been assigned in this basic block, so it is still equal to its
         // value in the input frame.
         abstractType = outputLocals[localIndex] = LOCAL_KIND | localIndex;
+      }
+      return abstractType;
     }
-    return abstractType;
   }
 
   /**
@@ -558,10 +558,10 @@ class Frame {
   private int pop() {
     if (outputStackTop > 0) {
       return outputStack[--outputStackTop];
+    } else {
+      // If the output frame stack is empty, pop from the input stack.
+      return STACK_KIND | -(--outputStackStart);
     }
-
-    // If the output frame stack is empty, pop from the input stack.
-    return STACK_KIND | -(--outputStackStart);
   }
 
   /**
@@ -647,10 +647,10 @@ class Frame {
         if (abstractType == initializedType) {
           if (abstractType == UNINITIALIZED_THIS) {
             return REFERENCE_KIND | symbolTable.addType(symbolTable.getClassName());
+          } else {
+            return REFERENCE_KIND
+                | symbolTable.addType(symbolTable.getType(abstractType & VALUE_MASK).value);
           }
-
-          return REFERENCE_KIND
-                  | symbolTable.addType(symbolTable.getType(abstractType & VALUE_MASK).value);
         }
       }
     }
@@ -1122,13 +1122,13 @@ class Frame {
     // Compute the concrete types of the local variables at the end of the basic block corresponding
     // to this frame, by resolving its abstract output types, and merge these concrete types with
     // those of the local variables in the input frame of dstFrame.
-    int nLocal = inputLocals.length;
-    int nStack = inputStack.length;
+    int numLocal = inputLocals.length;
+    int numStack = inputStack.length;
     if (dstFrame.inputLocals == null) {
-      dstFrame.inputLocals = new int[nLocal];
+      dstFrame.inputLocals = new int[numLocal];
       frameChanged = true;
     }
-    for (int i = 0; i < nLocal; ++i) {
+    for (int i = 0; i < numLocal; ++i) {
       int concreteOutputType;
       if (outputLocals != null && i < outputLocals.length) {
         int abstractOutputType = outputLocals[i];
@@ -1152,7 +1152,7 @@ class Frame {
             // By definition, a STACK_KIND type designates the concrete type of a local variable at
             // the beginning of the basic block corresponding to this frame (which is known when
             // this method is called, but was not when the abstract type was computed).
-            concreteOutputType = dim + inputStack[nStack - (abstractOutputType & VALUE_MASK)];
+            concreteOutputType = dim + inputStack[numStack - (abstractOutputType & VALUE_MASK)];
             if ((abstractOutputType & TOP_IF_LONG_OR_DOUBLE_FLAG) != 0
                 && (concreteOutputType == LONG || concreteOutputType == DOUBLE)) {
               concreteOutputType = TOP;
@@ -1181,7 +1181,7 @@ class Frame {
     // frame (and the input stack of dstFrame should be compatible, i.e. merged, with a one
     // element stack containing the caught exception type).
     if (catchTypeIndex > 0) {
-      for (int i = 0; i < nLocal; ++i) {
+      for (int i = 0; i < numLocal; ++i) {
         frameChanged |= merge(symbolTable, inputLocals[i], dstFrame.inputLocals, i);
       }
       if (dstFrame.inputStack == null) {
@@ -1195,15 +1195,15 @@ class Frame {
     // Compute the concrete types of the stack operands at the end of the basic block corresponding
     // to this frame, by resolving its abstract output types, and merge these concrete types with
     // those of the stack operands in the input frame of dstFrame.
-    int nInputStack = inputStack.length + outputStackStart;
+    int numInputStack = inputStack.length + outputStackStart;
     if (dstFrame.inputStack == null) {
-      dstFrame.inputStack = new int[nInputStack + outputStackTop];
+      dstFrame.inputStack = new int[numInputStack + outputStackTop];
       frameChanged = true;
     }
     // First, do this for the stack operands that have not been popped in the basic block
     // corresponding to this frame, and which are therefore equal to their value in the input
     // frame (except for uninitialized types, which may have been initialized).
-    for (int i = 0; i < nInputStack; ++i) {
+    for (int i = 0; i < numInputStack; ++i) {
       int concreteOutputType = inputStack[i];
       if (initializations != null) {
         concreteOutputType = getInitializedType(symbolTable, concreteOutputType);
@@ -1224,7 +1224,7 @@ class Frame {
           concreteOutputType = TOP;
         }
       } else if (kind == STACK_KIND) {
-        concreteOutputType = dim + inputStack[nStack - (abstractOutputType & VALUE_MASK)];
+        concreteOutputType = dim + inputStack[numStack - (abstractOutputType & VALUE_MASK)];
         if ((abstractOutputType & TOP_IF_LONG_OR_DOUBLE_FLAG) != 0
             && (concreteOutputType == LONG || concreteOutputType == DOUBLE)) {
           concreteOutputType = TOP;
@@ -1235,7 +1235,8 @@ class Frame {
       if (initializations != null) {
         concreteOutputType = getInitializedType(symbolTable, concreteOutputType);
       }
-      frameChanged |= merge(symbolTable, concreteOutputType, dstFrame.inputStack, nInputStack + i);
+      frameChanged |=
+          merge(symbolTable, concreteOutputType, dstFrame.inputStack, numInputStack + i);
     }
     return frameChanged;
   }
@@ -1348,38 +1349,38 @@ class Frame {
     // Compute the number of locals, ignoring TOP types that are just after a LONG or a DOUBLE, and
     // all trailing TOP types.
     int[] localTypes = inputLocals;
-    int nLocal = 0;
-    int nTrailingTop = 0;
+    int numLocal = 0;
+    int numTrailingTop = 0;
     int i = 0;
     while (i < localTypes.length) {
       int localType = localTypes[i];
       i += (localType == LONG || localType == DOUBLE) ? 2 : 1;
       if (localType == TOP) {
-        nTrailingTop++;
+        numTrailingTop++;
       } else {
-        nLocal += nTrailingTop + 1;
-        nTrailingTop = 0;
+        numLocal += numTrailingTop + 1;
+        numTrailingTop = 0;
       }
     }
     // Compute the stack size, ignoring TOP types that are just after a LONG or a DOUBLE.
     int[] stackTypes = inputStack;
-    int nStack = 0;
+    int numStack = 0;
     i = 0;
     while (i < stackTypes.length) {
       int stackType = stackTypes[i];
       i += (stackType == LONG || stackType == DOUBLE) ? 2 : 1;
-      nStack++;
+      numStack++;
     }
     // Visit the frame and its content.
-    int frameIndex = methodWriter.visitFrameStart(owner.bytecodeOffset, nLocal, nStack);
+    int frameIndex = methodWriter.visitFrameStart(owner.bytecodeOffset, numLocal, numStack);
     i = 0;
-    while (nLocal-- > 0) {
+    while (numLocal-- > 0) {
       int localType = localTypes[i];
       i += (localType == LONG || localType == DOUBLE) ? 2 : 1;
       methodWriter.visitAbstractType(frameIndex++, localType);
     }
     i = 0;
-    while (nStack-- > 0) {
+    while (numStack-- > 0) {
       int stackType = stackTypes[i];
       i += (stackType == LONG || stackType == DOUBLE) ? 2 : 1;
       methodWriter.visitAbstractType(frameIndex++, stackType);

--- a/src/main/java/org/datanucleus/enhancer/asm/Handler.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Handler.java
@@ -119,10 +119,9 @@ final class Handler {
   static Handler removeRange(final Handler firstHandler, final Label start, final Label end) {
     if (firstHandler == null) {
       return null;
+    } else {
+      firstHandler.nextHandler = removeRange(firstHandler.nextHandler, start, end);
     }
-
-    firstHandler.nextHandler = removeRange(firstHandler.nextHandler, start, end);
-
     int handlerStart = firstHandler.startPc.bytecodeOffset;
     int handlerEnd = firstHandler.endPc.bytecodeOffset;
     int rangeStart = start.bytecodeOffset;
@@ -135,10 +134,10 @@ final class Handler {
       if (rangeEnd >= handlerEnd) {
         // If [handlerStart,handlerEnd[ is included in [rangeStart,rangeEnd[, remove firstHandler.
         return firstHandler.nextHandler;
+      } else {
+        // [handlerStart,handlerEnd[ - [rangeStart,rangeEnd[ = [rangeEnd,handlerEnd[
+        return new Handler(firstHandler, end, firstHandler.endPc);
       }
-
-      // [handlerStart,handlerEnd[ - [rangeStart,rangeEnd[ = [rangeEnd,handlerEnd[
-      return new Handler(firstHandler, end, firstHandler.endPc);
     } else if (rangeEnd >= handlerEnd) {
       // [handlerStart,handlerEnd[ - [rangeStart,rangeEnd[ = [handlerStart,rangeStart[
       return new Handler(firstHandler, firstHandler.startPc, start);

--- a/src/main/java/org/datanucleus/enhancer/asm/Label.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Label.java
@@ -178,7 +178,7 @@ public class Label {
    *       and {@link #FORWARD_REFERENCE_HANDLE_MASK}.
    * </ul>
    *
-   * For instance, for an ifnull instruction at bytecode offset x, 'sourceInsnBytecodeOffset' is
+   * <p>For instance, for an ifnull instruction at bytecode offset x, 'sourceInsnBytecodeOffset' is
    * equal to x, and 'reference' is of type {@link #FORWARD_REFERENCE_TYPE_SHORT} with value x + 1
    * (because the ifnull instruction uses a 2 bytes bytecode offset operand stored one byte after
    * the start of the instruction itself). For the default case of a lookupswitch instruction at

--- a/src/main/java/org/datanucleus/enhancer/asm/MethodTooLargeException.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/MethodTooLargeException.java
@@ -34,8 +34,8 @@ package org.datanucleus.enhancer.asm;
  * @author Jason Zaugg
  */
 public final class MethodTooLargeException extends IndexOutOfBoundsException {
+  private static final long serialVersionUID = 6807380416709738314L;
 
-  private static final long serialVersionUID = -378622316336483540L;
   private final String className;
   private final String methodName;
   private final String descriptor;
@@ -61,22 +61,38 @@ public final class MethodTooLargeException extends IndexOutOfBoundsException {
     this.codeSize = codeSize;
   }
 
-  /** @return the internal name of the owner class. */
+  /**
+   * Returns the internal name of the owner class.
+   *
+   * @return the internal name of the owner class.
+   */
   public String getClassName() {
     return className;
   }
 
-  /** @return the name of the method. */
+  /**
+   * Returns the name of the method.
+   *
+   * @return the name of the method.
+   */
   public String getMethodName() {
     return methodName;
   }
 
-  /** @return the descriptor of the method. */
+  /**
+   * Returns the descriptor of the method.
+   *
+   * @return the descriptor of the method.
+   */
   public String getDescriptor() {
     return descriptor;
   }
 
-  /** @return the size of the method's Code attribute, in bytes. */
+  /**
+   * Returns the size of the method's Code attribute, in bytes.
+   *
+   * @return the size of the method's Code attribute, in bytes.
+   */
   public int getCodeSize() {
     return codeSize;
   }

--- a/src/main/java/org/datanucleus/enhancer/asm/MethodVisitor.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/MethodVisitor.java
@@ -52,7 +52,7 @@ public abstract class MethodVisitor {
 
   /**
    * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   protected final int api;
 
@@ -63,8 +63,7 @@ public abstract class MethodVisitor {
    * Constructs a new {@link MethodVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   public MethodVisitor(final int api) {
     this(api, null);
@@ -74,16 +73,12 @@ public abstract class MethodVisitor {
    * Constructs a new {@link MethodVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link
-   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link
-   *     Opcodes#ASM7_EXPERIMENTAL}.
+   *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
    * @param methodVisitor the method visitor to which this visitor must delegate method calls. May
    *     be null.
    */
   public MethodVisitor(final int api, final MethodVisitor methodVisitor) {
-    if (api != Opcodes.ASM6
-        && api != Opcodes.ASM5
-        && api != Opcodes.ASM4
-        && api != Opcodes.ASM7_EXPERIMENTAL) {
+    if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
       throw new IllegalArgumentException();
     }
     this.api = api;
@@ -248,15 +243,15 @@ public abstract class MethodVisitor {
    *         <li>{@link Opcodes#F_SAME} representing frame with exactly the same locals as the
    *             previous frame and with the empty stack.
    *         <li>{@link Opcodes#F_SAME1} representing frame with exactly the same locals as the
-   *             previous frame and with single value on the stack ( <code>nStack</code> is 1 and
+   *             previous frame and with single value on the stack ( <code>numStack</code> is 1 and
    *             <code>stack[0]</code> contains value for the type of the stack item).
    *         <li>{@link Opcodes#F_APPEND} representing frame with current locals are the same as the
    *             locals in the previous frame, except that additional locals are defined (<code>
-   *             nLocal</code> is 1, 2 or 3 and <code>local</code> elements contains values
+   *             numLocal</code> is 1, 2 or 3 and <code>local</code> elements contains values
    *             representing added types).
    *         <li>{@link Opcodes#F_CHOP} representing frame with current locals are the same as the
    *             locals in the previous frame, except that the last 1-3 locals are absent and with
-   *             the empty stack (<code>nLocals</code> is 1, 2 or 3).
+   *             the empty stack (<code>numLocal</code> is 1, 2 or 3).
    *         <li>{@link Opcodes#F_FULL} representing complete frame data.
    *       </ul>
    * </ul>
@@ -269,7 +264,7 @@ public abstract class MethodVisitor {
    * @param type the type of this stack map frame. Must be {@link Opcodes#F_NEW} for expanded
    *     frames, or {@link Opcodes#F_FULL}, {@link Opcodes#F_APPEND}, {@link Opcodes#F_CHOP}, {@link
    *     Opcodes#F_SAME} or {@link Opcodes#F_APPEND}, {@link Opcodes#F_SAME1} for compressed frames.
-   * @param nLocal the number of local variables in the visited frame.
+   * @param numLocal the number of local variables in the visited frame.
    * @param local the local variable types in this frame. This array must not be modified. Primitive
    *     types are represented by {@link Opcodes#TOP}, {@link Opcodes#INTEGER}, {@link
    *     Opcodes#FLOAT}, {@link Opcodes#LONG}, {@link Opcodes#DOUBLE}, {@link Opcodes#NULL} or
@@ -277,7 +272,7 @@ public abstract class MethodVisitor {
    *     Reference types are represented by String objects (representing internal names), and
    *     uninitialized types by Label objects (this label designates the NEW instruction that
    *     created this uninitialized value).
-   * @param nStack the number of operand stack elements in the visited frame.
+   * @param numStack the number of operand stack elements in the visited frame.
    * @param stack the operand stack types in this frame. This array must not be modified. Its
    *     content has the same format as the "local" array.
    * @throws IllegalStateException if a frame is visited just after another one, without any
@@ -286,12 +281,12 @@ public abstract class MethodVisitor {
    */
   public void visitFrame(
       final int type,
-      final int nLocal,
+      final int numLocal,
       final Object[] local,
-      final int nStack,
+      final int numStack,
       final Object[] stack) {
     if (mv != null) {
-      mv.visitFrame(type, nLocal, local, nStack, stack);
+      mv.visitFrame(type, numLocal, local, numStack, stack);
     }
   }
 
@@ -395,7 +390,7 @@ public abstract class MethodVisitor {
    *     Type#getInternalName()}).
    * @param name the method's name.
    * @param descriptor the method's descriptor (see {@link Type}).
-   * @deprecated
+   * @deprecated use {@link #visitMethodInsn(int, String, String, String, boolean)} instead.
    */
   @Deprecated
   public void visitMethodInsn(
@@ -532,7 +527,7 @@ public abstract class MethodVisitor {
    *
    * @param value the constant to be loaded on the stack. This parameter must be a non null {@link
    *     Integer}, a {@link Float}, a {@link Long}, a {@link Double}, a {@link String}, a {@link
-   *     Type} of OBJECT or ARRAY sort for <tt>.class</tt> constants, for classes whose version is
+   *     Type} of OBJECT or ARRAY sort for {@code .class} constants, for classes whose version is
    *     49, a {@link Type} of METHOD sort for MethodType, a {@link Handle} for MethodHandle
    *     constants, for classes whose version is 51 or a {@link ConstantDynamic} for a constant
    *     dynamic for classes whose version is 55.
@@ -543,7 +538,7 @@ public abstract class MethodVisitor {
             || (value instanceof Type && ((Type) value).getSort() == Type.METHOD))) {
       throw new UnsupportedOperationException(REQUIRES_ASM5);
     }
-    if (api != Opcodes.ASM7_EXPERIMENTAL && value instanceof ConstantDynamic) {
+    if (api != Opcodes.ASM7 && value instanceof ConstantDynamic) {
       throw new UnsupportedOperationException("This feature requires ASM7");
     }
     if (mv != null) {
@@ -569,8 +564,8 @@ public abstract class MethodVisitor {
    * @param min the minimum key value.
    * @param max the maximum key value.
    * @param dflt beginning of the default handler block.
-   * @param labels beginnings of the handler blocks. <tt>labels[i]</tt> is the beginning of the
-   *     handler block for the <tt>min + i</tt> key.
+   * @param labels beginnings of the handler blocks. {@code labels[i]} is the beginning of the
+   *     handler block for the {@code min + i} key.
    */
   public void visitTableSwitchInsn(
       final int min, final int max, final Label dflt, final Label... labels) {
@@ -584,8 +579,8 @@ public abstract class MethodVisitor {
    *
    * @param dflt beginning of the default handler block.
    * @param keys the values of the keys.
-   * @param labels beginnings of the handler blocks. <tt>labels[i]</tt> is the beginning of the
-   *     handler block for the <tt>keys[i]</tt> key.
+   * @param labels beginnings of the handler blocks. {@code labels[i]} is the beginning of the
+   *     handler block for the {@code keys[i]} key.
    */
   public void visitLookupSwitchInsn(final Label dflt, final int[] keys, final Label[] labels) {
     if (mv != null) {

--- a/src/main/java/org/datanucleus/enhancer/asm/MethodWriter.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/MethodWriter.java
@@ -342,15 +342,17 @@ final class MethodWriter extends MethodVisitor {
   /** The local_variable_table_length field of the LocalVariableTable code attribute. */
   private int localVariableTableLength;
 
-  /** The local_variable_table array of the LocalVariableTable code attribute, or <tt>null</tt>. */
+  /**
+   * The local_variable_table array of the LocalVariableTable code attribute, or <tt>null</tt>.
+   */
   private ByteVector localVariableTable;
 
   /** The local_variable_type_table_length field of the LocalVariableTypeTable code attribute. */
   private int localVariableTypeTableLength;
 
   /**
-   * The local_variable_type_table array of the LocalVariableTypeTable code attribute, or
-   * <tt>null</tt>.
+   * The local_variable_type_table array of the LocalVariableTypeTable code attribute, or {@literal
+   * null}.
    */
   private ByteVector localVariableTypeTable;
 
@@ -411,8 +413,8 @@ final class MethodWriter extends MethodVisitor {
 
   /**
    * The runtime visible parameter annotations of this method. Each array element contains the last
-   * annotation of a parameter (which can be <tt>null</tt> - the previous ones can be accessed with
-   * the {@link AnnotationWriter#previousAnnotation} field). May be <tt>null</tt>.
+   * annotation of a parameter (which can be <tt>null</tt> - the previous ones can be accessed
+   * with the {@link AnnotationWriter#previousAnnotation} field). May be <tt>null</tt>.
    */
   private AnnotationWriter[] lastRuntimeVisibleParameterAnnotations;
 
@@ -421,8 +423,8 @@ final class MethodWriter extends MethodVisitor {
 
   /**
    * The runtime invisible parameter annotations of this method. Each array element contains the
-   * last annotation of a parameter (which can be <tt>null</tt> - the previous ones can be accessed
-   * with the {@link AnnotationWriter#previousAnnotation} field). May be <tt>null</tt>.
+   * last annotation of a parameter (which can be <tt>null</tt> - the previous ones can be
+   * accessed with the {@link AnnotationWriter#previousAnnotation} field). May be <tt>null</tt>.
    */
   private AnnotationWriter[] lastRuntimeInvisibleParameterAnnotations;
 
@@ -483,7 +485,7 @@ final class MethodWriter extends MethodVisitor {
   /**
    * The current basic block, i.e. the basic block of the last visited instruction. When {@link
    * #compute} is equal to {@link #COMPUTE_MAX_STACK_AND_LOCAL} or {@link #COMPUTE_ALL_FRAMES}, this
-   * field is <tt>null</tt> for unreachable code. When {@link #compute} is equal to {@link
+   * field is <tt>null} for unreachable code. When {@link #compute</tt> is equal to {@link
    * #COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES} or {@link #COMPUTE_INSERTED_FRAMES}, this field stays
    * unchanged throughout the whole method (i.e. the whole code is seen as a single basic block;
    * indeed, the existing frames are sufficient by hypothesis to compute any intermediate frame -
@@ -529,11 +531,10 @@ final class MethodWriter extends MethodVisitor {
    * The current stack map frame. The first element contains the bytecode offset of the instruction
    * to which the frame corresponds, the second element is the number of locals and the third one is
    * the number of stack elements. The local variables start at index 3 and are followed by the
-   * operand stack elements. In summary frame[0] = offset, frame[1] = nLocal, frame[2] = nStack,
-   * frame[3] = nLocal. Local variables and operand stack entries contain abstract types, as defined
-   * in {@link Frame}, but restricted to {@link Frame#CONSTANT_KIND}, {@link Frame#REFERENCE_KIND}
-   * or {@link Frame#UNINITIALIZED_KIND} abstract types. Long and double types use only one array
-   * entry.
+   * operand stack elements. In summary frame[0] = offset, frame[1] = numLocal, frame[2] = numStack.
+   * Local variables and operand stack entries contain abstract types, as defined in {@link Frame},
+   * but restricted to {@link Frame#CONSTANT_KIND}, {@link Frame#REFERENCE_KIND} or {@link
+   * Frame#UNINITIALIZED_KIND} abstract types. Long and double types use only one array entry.
    */
   private int[] currentFrame;
 
@@ -591,7 +592,7 @@ final class MethodWriter extends MethodVisitor {
       final String signature,
       final String[] exceptions,
       final int compute) {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
     this.symbolTable = symbolTable;
     this.accessFlags = "<init>".equals(name) ? access | Constants.ACC_CONSTRUCTOR : access;
     this.nameIndex = symbolTable.addConstantUtf8(name);
@@ -661,10 +662,10 @@ final class MethodWriter extends MethodVisitor {
     if (visible) {
       return lastRuntimeVisibleAnnotation =
           new AnnotationWriter(symbolTable, annotation, lastRuntimeVisibleAnnotation);
+    } else {
+      return lastRuntimeInvisibleAnnotation =
+          new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
     }
-
-    return lastRuntimeInvisibleAnnotation =
-            new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
   }
 
   @Override
@@ -681,10 +682,10 @@ final class MethodWriter extends MethodVisitor {
     if (visible) {
       return lastRuntimeVisibleTypeAnnotation =
           new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeVisibleTypeAnnotation);
+    } else {
+      return lastRuntimeInvisibleTypeAnnotation =
+          new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeInvisibleTypeAnnotation);
     }
-
-    return lastRuntimeInvisibleTypeAnnotation =
-            new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeInvisibleTypeAnnotation);
   }
 
   @Override
@@ -712,15 +713,15 @@ final class MethodWriter extends MethodVisitor {
       return lastRuntimeVisibleParameterAnnotations[parameter] =
           new AnnotationWriter(
               symbolTable, annotation, lastRuntimeVisibleParameterAnnotations[parameter]);
-    }
-
-    if (lastRuntimeInvisibleParameterAnnotations == null) {
+    } else {
+      if (lastRuntimeInvisibleParameterAnnotations == null) {
         lastRuntimeInvisibleParameterAnnotations =
-                new AnnotationWriter[Type.getArgumentTypes(descriptor).length];
+            new AnnotationWriter[Type.getArgumentTypes(descriptor).length];
+      }
+      return lastRuntimeInvisibleParameterAnnotations[parameter] =
+          new AnnotationWriter(
+              symbolTable, annotation, lastRuntimeInvisibleParameterAnnotations[parameter]);
     }
-    return lastRuntimeInvisibleParameterAnnotations[parameter] =
-            new AnnotationWriter(
-                symbolTable, annotation, lastRuntimeInvisibleParameterAnnotations[parameter]);
   }
 
   @Override
@@ -743,9 +744,9 @@ final class MethodWriter extends MethodVisitor {
   @Override
   public void visitFrame(
       final int type,
-      final int nLocal,
+      final int numLocal,
       final Object[] local,
-      final int nStack,
+      final int numStack,
       final Object[] stack) {
     if (compute == COMPUTE_ALL_FRAMES) {
       return;
@@ -758,17 +759,16 @@ final class MethodWriter extends MethodVisitor {
         // can't be set if EXPAND_ASM_INSNS is not used).
         currentBasicBlock.frame = new CurrentFrame(currentBasicBlock);
         currentBasicBlock.frame.setInputFrameFromDescriptor(
-            symbolTable, accessFlags, descriptor, nLocal);
+            symbolTable, accessFlags, descriptor, numLocal);
         currentBasicBlock.frame.accept(this);
       } else {
         if (type == Opcodes.F_NEW) {
           currentBasicBlock.frame.setInputFrameFromApiFormat(
-              symbolTable, nLocal, local, nStack, stack);
-        } else {
-          // In this case type is equal to F_INSERT by hypothesis, and currentBlock.frame contains
-          // the stack map frame at the current instruction, computed from the last F_NEW frame
-          // and the bytecode instructions in between (via calls to CurrentFrame#execute).
+              symbolTable, numLocal, local, numStack, stack);
         }
+        // If type is not F_NEW then it is F_INSERT by hypothesis, and currentBlock.frame contains
+        // the stack map frame at the current instruction, computed from the last F_NEW frame and
+        // the bytecode instructions in between (via calls to CurrentFrame#execute).
         currentBasicBlock.frame.accept(this);
       }
     } else if (type == Opcodes.F_NEW) {
@@ -779,12 +779,12 @@ final class MethodWriter extends MethodVisitor {
             symbolTable, accessFlags, descriptor, argumentsSize);
         implicitFirstFrame.accept(this);
       }
-      currentLocals = nLocal;
-      int frameIndex = visitFrameStart(code.length, nLocal, nStack);
-      for (int i = 0; i < nLocal; ++i) {
+      currentLocals = numLocal;
+      int frameIndex = visitFrameStart(code.length, numLocal, numStack);
+      for (int i = 0; i < numLocal; ++i) {
         currentFrame[frameIndex++] = Frame.getAbstractTypeFromApiFormat(symbolTable, local[i]);
       }
-      for (int i = 0; i < nStack; ++i) {
+      for (int i = 0; i < numStack; ++i) {
         currentFrame[frameIndex++] = Frame.getAbstractTypeFromApiFormat(symbolTable, stack[i]);
       }
       visitFrameEnd();
@@ -798,34 +798,34 @@ final class MethodWriter extends MethodVisitor {
         if (offsetDelta < 0) {
           if (type == Opcodes.F_SAME) {
             return;
+          } else {
+            throw new IllegalStateException();
           }
-
-          throw new IllegalStateException();
         }
       }
 
       switch (type) {
         case Opcodes.F_FULL:
-          currentLocals = nLocal;
-          stackMapTableEntries.putByte(Frame.FULL_FRAME).putShort(offsetDelta).putShort(nLocal);
-          for (int i = 0; i < nLocal; ++i) {
+          currentLocals = numLocal;
+          stackMapTableEntries.putByte(Frame.FULL_FRAME).putShort(offsetDelta).putShort(numLocal);
+          for (int i = 0; i < numLocal; ++i) {
             putFrameType(local[i]);
           }
-          stackMapTableEntries.putShort(nStack);
-          for (int i = 0; i < nStack; ++i) {
+          stackMapTableEntries.putShort(numStack);
+          for (int i = 0; i < numStack; ++i) {
             putFrameType(stack[i]);
           }
           break;
         case Opcodes.F_APPEND:
-          currentLocals += nLocal;
-          stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + nLocal).putShort(offsetDelta);
-          for (int i = 0; i < nLocal; ++i) {
+          currentLocals += numLocal;
+          stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + numLocal).putShort(offsetDelta);
+          for (int i = 0; i < numLocal; ++i) {
             putFrameType(local[i]);
           }
           break;
         case Opcodes.F_CHOP:
-          currentLocals -= nLocal;
-          stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED - nLocal).putShort(offsetDelta);
+          currentLocals -= numLocal;
+          stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED - numLocal).putShort(offsetDelta);
           break;
         case Opcodes.F_SAME:
           if (offsetDelta < 64) {
@@ -853,8 +853,8 @@ final class MethodWriter extends MethodVisitor {
     }
 
     if (compute == COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES) {
-      relativeStackSize = nStack;
-      for (int i = 0; i < nStack; ++i) {
+      relativeStackSize = numStack;
+      for (int i = 0; i < numStack; ++i) {
         if (stack[i] == Opcodes.LONG || stack[i] == Opcodes.DOUBLE) {
           relativeStackSize++;
         }
@@ -864,7 +864,7 @@ final class MethodWriter extends MethodVisitor {
       }
     }
 
-    maxStack = Math.max(maxStack, nStack);
+    maxStack = Math.max(maxStack, numStack);
     maxLocals = Math.max(maxLocals, currentLocals);
   }
 
@@ -1289,9 +1289,13 @@ final class MethodWriter extends MethodVisitor {
     // Add the instruction to the bytecode of the method.
     Symbol constantSymbol = symbolTable.addConstant(value);
     int constantIndex = constantSymbol.index;
+    char firstDescriptorChar;
     boolean isLongOrDouble =
         constantSymbol.tag == Symbol.CONSTANT_LONG_TAG
-            || constantSymbol.tag == Symbol.CONSTANT_DOUBLE_TAG;
+            || constantSymbol.tag == Symbol.CONSTANT_DOUBLE_TAG
+            || (constantSymbol.tag == Symbol.CONSTANT_DYNAMIC_TAG
+                && ((firstDescriptorChar = constantSymbol.value.charAt(0)) == 'J'
+                    || firstDescriptorChar == 'D'));
     if (isLongOrDouble) {
       code.put12(Constants.LDC2_W, constantIndex);
     } else if (constantIndex >= 256) {
@@ -1422,10 +1426,10 @@ final class MethodWriter extends MethodVisitor {
     if (visible) {
       return lastCodeRuntimeVisibleTypeAnnotation =
           new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeVisibleTypeAnnotation);
+    } else {
+      return lastCodeRuntimeInvisibleTypeAnnotation =
+          new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeInvisibleTypeAnnotation);
     }
-
-    return lastCodeRuntimeInvisibleTypeAnnotation =
-            new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeInvisibleTypeAnnotation);
   }
 
   @Override
@@ -1456,10 +1460,10 @@ final class MethodWriter extends MethodVisitor {
     if (visible) {
       return lastCodeRuntimeVisibleTypeAnnotation =
           new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeVisibleTypeAnnotation);
+    } else {
+      return lastCodeRuntimeInvisibleTypeAnnotation =
+          new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeInvisibleTypeAnnotation);
     }
-
-    return lastCodeRuntimeInvisibleTypeAnnotation =
-            new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeInvisibleTypeAnnotation);
   }
 
   @Override
@@ -1527,10 +1531,10 @@ final class MethodWriter extends MethodVisitor {
     if (visible) {
       return lastCodeRuntimeVisibleTypeAnnotation =
           new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeVisibleTypeAnnotation);
+    } else {
+      return lastCodeRuntimeInvisibleTypeAnnotation =
+          new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeInvisibleTypeAnnotation);
     }
-
-    return lastCodeRuntimeInvisibleTypeAnnotation =
-            new AnnotationWriter(symbolTable, typeAnnotation, lastCodeRuntimeInvisibleTypeAnnotation);
   }
 
   @Override
@@ -1643,7 +1647,7 @@ final class MethodWriter extends MethodVisitor {
           code.data[endOffset] = (byte) Opcodes.ATHROW;
           // Emit a frame for this unreachable block, with no local and a Throwable on the stack
           // (so that the ATHROW could consume this Throwable if it were reachable).
-          int frameIndex = visitFrameStart(startOffset, /* nLocal = */ 0, /* nStack = */ 1);
+          int frameIndex = visitFrameStart(startOffset, /* numLocal = */ 0, /* numStack = */ 1);
           currentFrame[frameIndex] =
               Frame.getAbstractTypeFromInternalName(symbolTable, "java/lang/Throwable");
           visitFrameEnd();
@@ -1815,18 +1819,18 @@ final class MethodWriter extends MethodVisitor {
    * Starts the visit of a new stack map frame, stored in {@link #currentFrame}.
    *
    * @param offset the bytecode offset of the instruction to which the frame corresponds.
-   * @param nLocal the number of local variables in the frame.
-   * @param nStack the number of stack elements in the frame.
+   * @param numLocal the number of local variables in the frame.
+   * @param numStack the number of stack elements in the frame.
    * @return the index of the next element to be written in this frame.
    */
-  int visitFrameStart(final int offset, final int nLocal, final int nStack) {
-    int frameLength = 3 + nLocal + nStack;
+  int visitFrameStart(final int offset, final int numLocal, final int numStack) {
+    int frameLength = 3 + numLocal + numStack;
     if (currentFrame == null || currentFrame.length < frameLength) {
       currentFrame = new int[frameLength];
     }
     currentFrame[0] = offset;
-    currentFrame[1] = nLocal;
-    currentFrame[2] = nStack;
+    currentFrame[1] = numLocal;
+    currentFrame[2] = numStack;
     return 3;
   }
 
@@ -1859,25 +1863,25 @@ final class MethodWriter extends MethodVisitor {
 
   /** Compresses and writes {@link #currentFrame} in a new StackMapTable entry. */
   private void putFrame() {
-    final int nLocal = currentFrame[1];
-    final int nStack = currentFrame[2];
+    final int numLocal = currentFrame[1];
+    final int numStack = currentFrame[2];
     if (symbolTable.getMajorVersion() < Opcodes.V1_6) {
       // Generate a StackMap attribute entry, which are always uncompressed.
-      stackMapTableEntries.putShort(currentFrame[0]).putShort(nLocal);
-      putAbstractTypes(3, 3 + nLocal);
-      stackMapTableEntries.putShort(nStack);
-      putAbstractTypes(3 + nLocal, 3 + nLocal + nStack);
+      stackMapTableEntries.putShort(currentFrame[0]).putShort(numLocal);
+      putAbstractTypes(3, 3 + numLocal);
+      stackMapTableEntries.putShort(numStack);
+      putAbstractTypes(3 + numLocal, 3 + numLocal + numStack);
       return;
     }
     final int offsetDelta =
         stackMapTableNumberOfEntries == 0
             ? currentFrame[0]
             : currentFrame[0] - previousFrame[0] - 1;
-    final int previousNlocal = previousFrame[1];
-    final int nLocalDelta = nLocal - previousNlocal;
+    final int previousNumlocal = previousFrame[1];
+    final int numLocalDelta = numLocal - previousNumlocal;
     int type = Frame.FULL_FRAME;
-    if (nStack == 0) {
-      switch (nLocalDelta) {
+    if (numStack == 0) {
+      switch (numLocalDelta) {
         case -3:
         case -2:
         case -1:
@@ -1895,7 +1899,7 @@ final class MethodWriter extends MethodVisitor {
           // Keep the FULL_FRAME type.
           break;
       }
-    } else if (nLocalDelta == 0 && nStack == 1) {
+    } else if (numLocalDelta == 0 && numStack == 1) {
       type =
           offsetDelta < 63
               ? Frame.SAME_LOCALS_1_STACK_ITEM_FRAME
@@ -1904,7 +1908,7 @@ final class MethodWriter extends MethodVisitor {
     if (type != Frame.FULL_FRAME) {
       // Verify if locals are the same as in the previous frame.
       int frameIndex = 3;
-      for (int i = 0; i < previousNlocal && i < nLocal; i++) {
+      for (int i = 0; i < previousNumlocal && i < numLocal; i++) {
         if (currentFrame[frameIndex] != previousFrame[frameIndex]) {
           type = Frame.FULL_FRAME;
           break;
@@ -1918,30 +1922,35 @@ final class MethodWriter extends MethodVisitor {
         break;
       case Frame.SAME_LOCALS_1_STACK_ITEM_FRAME:
         stackMapTableEntries.putByte(Frame.SAME_LOCALS_1_STACK_ITEM_FRAME + offsetDelta);
-        putAbstractTypes(3 + nLocal, 4 + nLocal);
+        putAbstractTypes(3 + numLocal, 4 + numLocal);
         break;
       case Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED:
         stackMapTableEntries
             .putByte(Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED)
             .putShort(offsetDelta);
-        putAbstractTypes(3 + nLocal, 4 + nLocal);
+        putAbstractTypes(3 + numLocal, 4 + numLocal);
         break;
       case Frame.SAME_FRAME_EXTENDED:
         stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED).putShort(offsetDelta);
         break;
       case Frame.CHOP_FRAME:
-        stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + nLocalDelta).putShort(offsetDelta);
+        stackMapTableEntries
+            .putByte(Frame.SAME_FRAME_EXTENDED + numLocalDelta)
+            .putShort(offsetDelta);
         break;
       case Frame.APPEND_FRAME:
-        stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + nLocalDelta).putShort(offsetDelta);
-        putAbstractTypes(3 + previousNlocal, 3 + nLocal);
+        stackMapTableEntries
+            .putByte(Frame.SAME_FRAME_EXTENDED + numLocalDelta)
+            .putShort(offsetDelta);
+        putAbstractTypes(3 + previousNumlocal, 3 + numLocal);
         break;
       case Frame.FULL_FRAME:
       default:
-        stackMapTableEntries.putByte(Frame.FULL_FRAME).putShort(offsetDelta).putShort(nLocal);
-        putAbstractTypes(3, 3 + nLocal);
-        stackMapTableEntries.putShort(nStack);
-        putAbstractTypes(3 + nLocal, 3 + nLocal + nStack);
+        stackMapTableEntries.putByte(Frame.FULL_FRAME).putShort(offsetDelta).putShort(numLocal);
+        putAbstractTypes(3, 3 + numLocal);
+        stackMapTableEntries.putShort(numStack);
+        putAbstractTypes(3 + numLocal, 3 + numLocal + numStack);
+        break;
     }
   }
 

--- a/src/main/java/org/datanucleus/enhancer/asm/ModuleVisitor.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ModuleVisitor.java
@@ -39,7 +39,7 @@ package org.datanucleus.enhancer.asm;
 public abstract class ModuleVisitor {
   /**
    * The ASM API version implemented by this visitor. The value of this field must be one of {@link
-   * Opcodes#ASM6} or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   * Opcodes#ASM6} or {@link Opcodes#ASM7}.
    */
   protected final int api;
 
@@ -50,7 +50,7 @@ public abstract class ModuleVisitor {
    * Constructs a new {@link ModuleVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link Opcodes#ASM6}
-   *     or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   *     or {@link Opcodes#ASM7}.
    */
   public ModuleVisitor(final int api) {
     this(api, null);
@@ -60,12 +60,12 @@ public abstract class ModuleVisitor {
    * Constructs a new {@link ModuleVisitor}.
    *
    * @param api the ASM API version implemented by this visitor. Must be one of {@link Opcodes#ASM6}
-   *     or {@link Opcodes#ASM7_EXPERIMENTAL}.
+   *     or {@link Opcodes#ASM7}.
    * @param moduleVisitor the module visitor to which this visitor must delegate method calls. May
    *     be null.
    */
   public ModuleVisitor(final int api, final ModuleVisitor moduleVisitor) {
-    if (api != Opcodes.ASM6 && api != Opcodes.ASM7_EXPERIMENTAL) {
+    if (api != Opcodes.ASM6 && api != Opcodes.ASM7) {
       throw new IllegalArgumentException();
     }
     this.api = api;

--- a/src/main/java/org/datanucleus/enhancer/asm/ModuleWriter.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/ModuleWriter.java
@@ -94,7 +94,7 @@ final class ModuleWriter extends ModuleVisitor {
   private int mainClassIndex;
 
   ModuleWriter(final SymbolTable symbolTable, final int name, final int access, final int version) {
-    super(Opcodes.ASM6);
+    super(Opcodes.ASM7);
     this.symbolTable = symbolTable;
     this.moduleNameIndex = name;
     this.moduleFlags = access;

--- a/src/main/java/org/datanucleus/enhancer/asm/Opcodes.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Opcodes.java
@@ -38,6 +38,7 @@ package org.datanucleus.enhancer.asm;
  * @author Eric Bruneton
  * @author Eugene Kuleshov
  */
+// DontCheck(InterfaceIsType): can't be fixed (for backward binary compatibility).
 public interface Opcodes {
 
   // ASM API versions.
@@ -45,13 +46,7 @@ public interface Opcodes {
   int ASM4 = 4 << 16 | 0 << 8;
   int ASM5 = 5 << 16 | 0 << 8;
   int ASM6 = 6 << 16 | 0 << 8;
-
-  /**
-   * <b>Experimental, use at your own risk. This field will be renamed when it becomes stable, this
-   * will break existing code using it</b>.
-   *
-   */
-  int ASM7_EXPERIMENTAL = 1 << 24 | 7 << 16 | 0 << 8;
+  int ASM7 = 7 << 16 | 0 << 8;
 
   // Java ClassFile versions (the minor version is stored in the 16 most
   // significant bits, and the
@@ -73,12 +68,10 @@ public interface Opcodes {
   /**
    * Version flag indicating that the class is using 'preview' features.
    *
-   * <p>{@code version & V_PREVIEW_EXPERIMENTAL == V_PREVIEW_EXPERIMENTAL} tests if a version is
-   * flagged with {@code V_PREVIEW_EXPERIMENTAL}.
-   *
-   * @deprecated This API is experimental.
+   * <p>{@code version & V_PREVIEW == V_PREVIEW} tests if a version is flagged with {@code
+   * V_PREVIEW}.
    */
-  @Deprecated int V_PREVIEW_EXPERIMENTAL = 0xFFFF0000;
+  int V_PREVIEW = 0xFFFF0000;
 
   // Access flags values, defined in
   // - https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.1-200-E.1

--- a/src/main/java/org/datanucleus/enhancer/asm/Symbol.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/Symbol.java
@@ -206,7 +206,8 @@ abstract class Symbol {
    *     the (ASM specific) type table of a class (depending on 'tag').
    * @param tag the symbol type. Must be one of the static tag values defined in this class.
    * @param owner The internal name of the symbol's owner class. Maybe <tt>null</tt>.
-   * @param name The name of the symbol's corresponding class field or method. Maybe <tt>null</tt>.
+   * @param name The name of the symbol's corresponding class field or method. Maybe {@literal
+   *     null}.
    * @param value The string value of this symbol. Maybe <tt>null</tt>.
    * @param data The numeric value of this symbol.
    */
@@ -226,6 +227,8 @@ abstract class Symbol {
   }
 
   /**
+   * Returns the result {@link Type#getArgumentsAndReturnSizes} on {@link #value}.
+   *
    * @return the result {@link Type#getArgumentsAndReturnSizes} on {@link #value} (memoized in
    *     {@link #info} for efficiency). This should only be used for {@link
    *     #CONSTANT_METHODREF_TAG}, {@link #CONSTANT_INTERFACE_METHODREF_TAG} and {@link

--- a/src/main/java/org/datanucleus/enhancer/asm/SymbolTable.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/SymbolTable.java
@@ -40,58 +40,6 @@ package org.datanucleus.enhancer.asm;
 final class SymbolTable {
 
   /**
-   * An entry of a SymbolTable. This concrete and private subclass of {@link Symbol} adds two fields
-   * which are only used inside SymbolTable, to implement hash sets of symbols (in order to avoid
-   * duplicate symbols). See {@link #entries}.
-   *
-   * @author Eric Bruneton
-   */
-  private static class Entry extends Symbol {
-
-    /** The hash code of this entry. */
-    final int hashCode;
-
-    /**
-     * Another entry (and so on recursively) having the same hash code (modulo the size of {@link
-     * #entries}) as this one.
-     */
-    Entry next;
-
-    Entry(
-        final int index,
-        final int tag,
-        final String owner,
-        final String name,
-        final String value,
-        final long data,
-        final int hashCode) {
-      super(index, tag, owner, name, value, data);
-      this.hashCode = hashCode;
-    }
-
-    Entry(final int index, final int tag, final String value, final int hashCode) {
-      super(index, tag, /* owner = */ null, /* name = */ null, value, /* data = */ 0);
-      this.hashCode = hashCode;
-    }
-
-    Entry(final int index, final int tag, final String value, final long data, final int hashCode) {
-      super(index, tag, /* owner = */ null, /* name = */ null, value, data);
-      this.hashCode = hashCode;
-    }
-
-    Entry(
-        final int index, final int tag, final String name, final String value, final int hashCode) {
-      super(index, tag, /* owner = */ null, name, value, /* data = */ 0);
-      this.hashCode = hashCode;
-    }
-
-    Entry(final int index, final int tag, final long data, final int hashCode) {
-      super(index, tag, /* owner = */ null, /* name = */ null, /* value = */ null, data);
-      this.hashCode = hashCode;
-    }
-  }
-
-  /**
    * The ClassWriter to which this SymbolTable belongs. This is only used to get access to {@link
    * ClassWriter#getCommonSuperClass} and to serialize custom attributes with {@link
    * Attribute#write}.
@@ -161,7 +109,7 @@ final class SymbolTable {
    * be stored in the constant pool. This type table is used by the control flow and data flow
    * analysis algorithm used to compute stack map frames from scratch. This array stores {@link
    * Symbol#TYPE_TAG} and {@link Symbol#UNINITIALIZED_TYPE_TAG}) Symbol. The type symbol at index
-   * <tt>i</tt> has its {@link Symbol#index} equal to <tt>i</tt> (and vice versa).
+   * {@code i} has its {@link Symbol#index} equal to {@code i} (and vice versa).
    */
   private Entry[] typeTable;
 
@@ -203,6 +151,7 @@ final class SymbolTable {
     // method calls below), and to account for bootstrap method entries.
     entries = new Entry[constantPoolCount * 2];
     char[] charBuffer = new char[classReader.getMaxStringLength()];
+    boolean hasBootstrapMethods = false;
     int itemIndex = 1;
     while (itemIndex < constantPoolCount) {
       int itemOffset = classReader.getItem(itemIndex);
@@ -223,7 +172,7 @@ final class SymbolTable {
           break;
         case Symbol.CONSTANT_INTEGER_TAG:
         case Symbol.CONSTANT_FLOAT_TAG:
-          addConstantInteger(itemIndex, itemTag, classReader.readInt(itemOffset));
+          addConstantIntegerOrFloat(itemIndex, itemTag, classReader.readInt(itemOffset));
           break;
         case Symbol.CONSTANT_NAME_AND_TYPE_TAG:
           addConstantNameAndType(
@@ -233,10 +182,10 @@ final class SymbolTable {
           break;
         case Symbol.CONSTANT_LONG_TAG:
         case Symbol.CONSTANT_DOUBLE_TAG:
-          addConstantLong(itemIndex, itemTag, classReader.readLong(itemOffset));
+          addConstantLongOrDouble(itemIndex, itemTag, classReader.readLong(itemOffset));
           break;
         case Symbol.CONSTANT_UTF8_TAG:
-          addConstantUtf8(itemIndex, classReader.readUTF(itemIndex, charBuffer));
+          addConstantUtf8(itemIndex, classReader.readUtf(itemIndex, charBuffer));
           break;
         case Symbol.CONSTANT_METHOD_HANDLE_TAG:
           int memberRefItemOffset =
@@ -252,6 +201,7 @@ final class SymbolTable {
           break;
         case Symbol.CONSTANT_DYNAMIC_TAG:
         case Symbol.CONSTANT_INVOKE_DYNAMIC_TAG:
+          hasBootstrapMethods = true;
           nameAndTypeItemOffset =
               classReader.getItem(classReader.readUnsignedShort(itemOffset + 2));
           addConstantDynamicOrInvokeDynamicReference(
@@ -276,7 +226,23 @@ final class SymbolTable {
           (itemTag == Symbol.CONSTANT_LONG_TAG || itemTag == Symbol.CONSTANT_DOUBLE_TAG) ? 2 : 1;
     }
 
-    // Copy the BootstrapMethods 'bootstrap_methods' array binary content, if any.
+    // Copy the BootstrapMethods, if any.
+    if (hasBootstrapMethods) {
+      copyBootstrapMethods(classReader, charBuffer);
+    }
+  }
+
+  /**
+   * Read the BootstrapMethods 'bootstrap_methods' array binary content and add them as entries of
+   * the SymbolTable.
+   *
+   * @param classReader the ClassReader whose bootstrap methods must be copied to initialize the
+   *     SymbolTable.
+   * @param charBuffer a buffer used to read strings in the constant pool.
+   */
+  private void copyBootstrapMethods(final ClassReader classReader, final char[] charBuffer) {
+    // Find attributOffset of the 'bootstrap_methods' array.
+    byte[] inputBytes = classReader.b;
     int currentAttributeOffset = classReader.getFirstAttributeOffset();
     for (int i = classReader.readUnsignedShort(currentAttributeOffset - 2); i > 0; --i) {
       String attributeName = classReader.readUTF8(currentAttributeOffset, charBuffer);
@@ -313,19 +279,29 @@ final class SymbolTable {
   }
 
   /**
-   * @return the ClassReader from which this SymbolTable was constructed, or <tt>null</tt> if it was
-   *     constructed from scratch.
+   * Returns the ClassReader from which this SymbolTable was constructed.
+   *
+   * @return the ClassReader from which this SymbolTable was constructed, or <tt>null</tt> if it
+   *     was constructed from scratch.
    */
   ClassReader getSource() {
     return sourceClassReader;
   }
 
-  /** @return the major version of the class to which this symbol table belongs. */
+  /**
+   * Returns the major version of the class to which this symbol table belongs.
+   *
+   * @return the major version of the class to which this symbol table belongs.
+   */
   int getMajorVersion() {
     return majorVersion;
   }
 
-  /** @return the internal name of the class to which this symbol table belongs. */
+  /**
+   * Returns the internal name of the class to which this symbol table belongs.
+   *
+   * @return the internal name of the class to which this symbol table belongs.
+   */
   String getClassName() {
     return className;
   }
@@ -344,12 +320,20 @@ final class SymbolTable {
     return addConstantClass(className).index;
   }
 
-  /** @return the number of items in this symbol table's constant_pool array (plus 1). */
+  /**
+   * Returns the number of items in this symbol table's constant_pool array (plus 1).
+   *
+   * @return the number of items in this symbol table's constant_pool array (plus 1).
+   */
   int getConstantPoolCount() {
     return constantPoolCount;
   }
 
-  /** @return the length in bytes of this symbol table's constant_pool array. */
+  /**
+   * Returns the length in bytes of this symbol table's constant_pool array.
+   *
+   * @return the length in bytes of this symbol table's constant_pool array.
+   */
   int getConstantPoolLength() {
     return constantPool.length;
   }
@@ -374,9 +358,9 @@ final class SymbolTable {
     if (bootstrapMethods != null) {
       addConstantUtf8(Constants.BOOTSTRAP_METHODS);
       return 8 + bootstrapMethods.length;
+    } else {
+      return 0;
     }
-
-    return 0;
   }
 
   /**
@@ -400,6 +384,8 @@ final class SymbolTable {
   // -----------------------------------------------------------------------------------------------
 
   /**
+   * Returns the list of entries which can potentially have the given hash code.
+   *
    * @param hashCode a {@link Entry#hashCode} value.
    * @return the list of entries which can potentially have the given hash code. The list is stored
    *     via the {@link Entry#next} field.
@@ -510,7 +496,7 @@ final class SymbolTable {
           constantDynamic.getName(),
           constantDynamic.getDescriptor(),
           constantDynamic.getBootstrapMethod(),
-          constantDynamic.getBootstrapMethodArguments());
+          constantDynamic.getBootstrapMethodArgumentsUnsafe());
     } else {
       throw new IllegalArgumentException("value " + value);
     }
@@ -626,7 +612,7 @@ final class SymbolTable {
    * @return a new or already existing Symbol with the given value.
    */
   Symbol addConstantInteger(final int value) {
-    return addConstantInteger(Symbol.CONSTANT_INTEGER_TAG, value);
+    return addConstantIntegerOrFloat(Symbol.CONSTANT_INTEGER_TAG, value);
   }
 
   /**
@@ -637,7 +623,7 @@ final class SymbolTable {
    * @return a new or already existing Symbol with the given value.
    */
   Symbol addConstantFloat(final float value) {
-    return addConstantInteger(Symbol.CONSTANT_FLOAT_TAG, Float.floatToRawIntBits(value));
+    return addConstantIntegerOrFloat(Symbol.CONSTANT_FLOAT_TAG, Float.floatToRawIntBits(value));
   }
 
   /**
@@ -648,7 +634,7 @@ final class SymbolTable {
    * @param value an int or float.
    * @return a constant pool constant with the given tag and primitive values.
    */
-  private Symbol addConstantInteger(final int tag, final int value) {
+  private Symbol addConstantIntegerOrFloat(final int tag, final int value) {
     int hashCode = hash(tag, value);
     Entry entry = get(hashCode);
     while (entry != null) {
@@ -669,7 +655,7 @@ final class SymbolTable {
    * @param tag one of {@link Symbol#CONSTANT_INTEGER_TAG} or {@link Symbol#CONSTANT_FLOAT_TAG}.
    * @param value an int or float.
    */
-  private void addConstantInteger(final int index, final int tag, final int value) {
+  private void addConstantIntegerOrFloat(final int index, final int tag, final int value) {
     add(new Entry(index, tag, value, hash(tag, value)));
   }
 
@@ -681,7 +667,7 @@ final class SymbolTable {
    * @return a new or already existing Symbol with the given value.
    */
   Symbol addConstantLong(final long value) {
-    return addConstantLong(Symbol.CONSTANT_LONG_TAG, value);
+    return addConstantLongOrDouble(Symbol.CONSTANT_LONG_TAG, value);
   }
 
   /**
@@ -692,7 +678,7 @@ final class SymbolTable {
    * @return a new or already existing Symbol with the given value.
    */
   Symbol addConstantDouble(final double value) {
-    return addConstantLong(Symbol.CONSTANT_DOUBLE_TAG, Double.doubleToRawLongBits(value));
+    return addConstantLongOrDouble(Symbol.CONSTANT_DOUBLE_TAG, Double.doubleToRawLongBits(value));
   }
 
   /**
@@ -703,7 +689,7 @@ final class SymbolTable {
    * @param value a long or double.
    * @return a constant pool constant with the given tag and primitive values.
    */
-  private Symbol addConstantLong(final int tag, final long value) {
+  private Symbol addConstantLongOrDouble(final int tag, final long value) {
     int hashCode = hash(tag, value);
     Entry entry = get(hashCode);
     while (entry != null) {
@@ -719,13 +705,14 @@ final class SymbolTable {
   }
 
   /**
-   * Adds a new CONSTANT_Double_info to the constant pool of this symbol table.
+   * Adds a new CONSTANT_Long_info or CONSTANT_Double_info to the constant pool of this symbol
+   * table.
    *
    * @param index the constant pool index of the new Symbol.
    * @param tag one of {@link Symbol#CONSTANT_LONG_TAG} or {@link Symbol#CONSTANT_DOUBLE_TAG}.
    * @param value a long or double.
    */
-  private void addConstantLong(final int index, final int tag, final long value) {
+  private void addConstantLongOrDouble(final int index, final int tag, final long value) {
     add(new Entry(index, tag, value, hash(tag, value)));
   }
 
@@ -1131,6 +1118,8 @@ final class SymbolTable {
   // -----------------------------------------------------------------------------------------------
 
   /**
+   * Returns the type table element whose index is given.
+   *
    * @param typeIndex a type table index.
    * @return the type table element whose index is given.
    */
@@ -1154,7 +1143,7 @@ final class SymbolTable {
       }
       entry = entry.next;
     }
-    return addType(new Entry(typeCount, Symbol.TYPE_TAG, value, hashCode));
+    return addTypeInternal(new Entry(typeCount, Symbol.TYPE_TAG, value, hashCode));
   }
 
   /**
@@ -1178,7 +1167,7 @@ final class SymbolTable {
       }
       entry = entry.next;
     }
-    return addType(
+    return addTypeInternal(
         new Entry(typeCount, Symbol.UNINITIALIZED_TYPE_TAG, value, bytecodeOffset, hashCode));
   }
 
@@ -1219,7 +1208,7 @@ final class SymbolTable {
    * @return the index in {@link #typeTable} where the given type was added, which is also equal to
    *     entry's index by hypothesis.
    */
-  private int addType(final Entry entry) {
+  private int addTypeInternal(final Entry entry) {
     if (typeTable == null) {
       typeTable = new Entry[16];
     }
@@ -1273,5 +1262,57 @@ final class SymbolTable {
       final String value3,
       final int value4) {
     return 0x7FFFFFFF & (tag + value1.hashCode() * value2.hashCode() * value3.hashCode() * value4);
+  }
+
+  /**
+   * An entry of a SymbolTable. This concrete and private subclass of {@link Symbol} adds two fields
+   * which are only used inside SymbolTable, to implement hash sets of symbols (in order to avoid
+   * duplicate symbols). See {@link #entries}.
+   *
+   * @author Eric Bruneton
+   */
+  private static class Entry extends Symbol {
+
+    /** The hash code of this entry. */
+    final int hashCode;
+
+    /**
+     * Another entry (and so on recursively) having the same hash code (modulo the size of {@link
+     * #entries}) as this one.
+     */
+    Entry next;
+
+    Entry(
+        final int index,
+        final int tag,
+        final String owner,
+        final String name,
+        final String value,
+        final long data,
+        final int hashCode) {
+      super(index, tag, owner, name, value, data);
+      this.hashCode = hashCode;
+    }
+
+    Entry(final int index, final int tag, final String value, final int hashCode) {
+      super(index, tag, /* owner = */ null, /* name = */ null, value, /* data = */ 0);
+      this.hashCode = hashCode;
+    }
+
+    Entry(final int index, final int tag, final String value, final long data, final int hashCode) {
+      super(index, tag, /* owner = */ null, /* name = */ null, value, data);
+      this.hashCode = hashCode;
+    }
+
+    Entry(
+        final int index, final int tag, final String name, final String value, final int hashCode) {
+      super(index, tag, /* owner = */ null, name, value, /* data = */ 0);
+      this.hashCode = hashCode;
+    }
+
+    Entry(final int index, final int tag, final long data, final int hashCode) {
+      super(index, tag, /* owner = */ null, /* name = */ null, /* value = */ null, data);
+      this.hashCode = hashCode;
+    }
   }
 }

--- a/src/main/java/org/datanucleus/enhancer/asm/TypePath.java
+++ b/src/main/java/org/datanucleus/enhancer/asm/TypePath.java
@@ -34,7 +34,7 @@ package org.datanucleus.enhancer.asm;
  *
  * @author Eric Bruneton
  */
-public class TypePath {
+public final class TypePath {
 
   /** A type path step that steps into the element type of an array type. See {@link #getStep}. */
   public static final int ARRAY_ELEMENT = 0;

--- a/src/main/java/org/datanucleus/enhancer/asm/package.html
+++ b/src/main/java/org/datanucleus/enhancer/asm/package.html
@@ -1,7 +1,7 @@
 <html>
 <body>
-    ASM v6.2.1 : a small and fast bytecode manipulation framework.
-    This is repackaged from "org.ow2.asm" in ASM v6.2.1.
+    ASM v7.0 : a small and fast bytecode manipulation framework.
+    This is repackaged from "org.ow2.asm" in ASM v7.0.
     The only changes in the code were to fix javadocs error.
 </body>
 </html>


### PR DESCRIPTION
This PR upgrades repackaged [ASM to v7.0](https://gitlab.ow2.org/asm/asm/tags/ASM_7_0). The upgrade brings [support for JDK11](https://asm.ow2.io/versions.html). 

The upgrade resolves the issue raised in https://github.com/datanucleus/datanucleus-core/issues/314. The issue is marked as "requires a testcase", unfortunately it's not possible to express such test in code, but I can prepare a fork of [test-jpa](https://github.com/datanucleus/test-jpa) that fails when being compiled with JDK11. 

The javadoc errors were fixed after repackaging, so `mvn javadoc:javadoc` runs without any issues. 