### PR TITLE
Synchronize String parsing across converters

### DIFF
--- a/src/main/java/org/datanucleus/store/types/converters/ColorStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/ColorStringConverter.java
@@ -19,6 +19,9 @@ package org.datanucleus.store.types.converters;
 
 import java.awt.Color;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
+
 /**
  * Class to handle the conversion between java.awt.Color (RGBA) and a String form.
  */
@@ -32,17 +35,23 @@ public class ColorStringConverter implements TypeConverter<Color, String>
         {
             return null;
         }
-
-        int componentLength = (str.length()-1)/4;
-        String rStr = str.substring(1, 1+componentLength);
-        String gStr = str.substring(1+componentLength, 1+2*componentLength);
-        String bStr = str.substring(1+2*componentLength, 1+3*componentLength);
-        String aStr = str.substring(1+3*componentLength);
-        int r = Integer.parseInt(rStr, 16);
-        int g = Integer.parseInt(gStr, 16);
-        int b = Integer.parseInt(bStr, 16);
-        int a = Integer.parseInt(aStr, 16);
-        return new Color(r, g, b, a);
+        try
+        {
+            int componentLength = (str.length() - 1) / 4;
+            String rStr = str.substring(1, 1 + componentLength);
+            String gStr = str.substring(1 + componentLength, 1 + 2 * componentLength);
+            String bStr = str.substring(1 + 2 * componentLength, 1 + 3 * componentLength);
+            String aStr = str.substring(1 + 3 * componentLength);
+            int r = Integer.parseInt(rStr, 16);
+            int g = Integer.parseInt(gStr, 16);
+            int b = Integer.parseInt(bStr, 16);
+            int a = Integer.parseInt(aStr, 16);
+            return new Color(r, g, b, a);
+        }
+        catch (NumberFormatException nfe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Color.class.getName()), nfe);
+        }
     }
 
     public String toDatastoreType(Color c)

--- a/src/main/java/org/datanucleus/store/types/converters/DateStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/DateStringConverter.java
@@ -17,9 +17,9 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.types.converters;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 import org.datanucleus.exceptions.NucleusDataStoreException;
@@ -32,29 +32,8 @@ import org.datanucleus.util.Localiser;
 public class DateStringConverter implements TypeConverter<Date, String>, ColumnLengthDefiningTypeConverter
 {
     private static final long serialVersionUID = 4638239842151376340L;
-    private static final ThreadLocal<FormatterInfo> formatterThreadInfo = new ThreadLocal<FormatterInfo>()
-    {
-        protected FormatterInfo initialValue()
-        {
-            return new FormatterInfo();
-        }
-    };
 
-    static class FormatterInfo
-    {
-        SimpleDateFormat formatter;
-    }
-
-    private DateFormat getFormatter()
-    {
-        FormatterInfo formatInfo = formatterThreadInfo.get();
-        if (formatInfo.formatter == null)
-        {
-            // TODO Handle millisecs
-            formatInfo.formatter = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
-        }
-        return formatInfo.formatter;
-    }
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy");
 
     /* (non-Javadoc)
      * @see org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter#getDefaultColumnLength(int)
@@ -78,9 +57,9 @@ public class DateStringConverter implements TypeConverter<Date, String>, ColumnL
 
         try
         {
-            return getFormatter().parse(str);
+            return Date.from(Instant.from(FORMATTER.parse(str)));
         }
-        catch (ParseException pe)
+        catch (DateTimeParseException pe)
         {
             throw new NucleusDataStoreException(Localiser.msg("016002", str, Date.class.getName()), pe);
         }
@@ -88,6 +67,6 @@ public class DateStringConverter implements TypeConverter<Date, String>, ColumnL
 
     public String toDatastoreType(Date date)
     {
-        return date != null ? getFormatter().format(date) : null;
+        return date != null ? FORMATTER.format(date.toInstant()) : null;
     }
 }

--- a/src/main/java/org/datanucleus/store/types/converters/IntegerStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/IntegerStringConverter.java
@@ -17,6 +17,11 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.types.converters;
 
+import java.util.Calendar;
+
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
+
 /**
  * Class to handle the conversion between java.lang.Integer and a String form.
  */
@@ -37,7 +42,7 @@ public class IntegerStringConverter implements TypeConverter<Integer, String>
         }
         catch (NumberFormatException nfe)
         {
-            return null;
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Integer.class.getName()), nfe);
         }
     }
 
@@ -47,6 +52,6 @@ public class IntegerStringConverter implements TypeConverter<Integer, String>
         {
             return null;
         }
-        return "" + val;
+        return val.toString();
     }
 }

--- a/src/main/java/org/datanucleus/store/types/converters/LocalDateStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/LocalDateStringConverter.java
@@ -18,9 +18,10 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
-import org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter;
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.LocalDate and a String form.
@@ -36,7 +37,14 @@ public class LocalDateStringConverter implements TypeConverter<LocalDate, String
             return null;
         }
 
-        return LocalDate.parse(str);
+        try
+        {
+            return LocalDate.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, LocalDate.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(LocalDate date)

--- a/src/main/java/org/datanucleus/store/types/converters/LocalDateTimeStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/LocalDateTimeStringConverter.java
@@ -18,9 +18,12 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter;
 import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.LocalDateTime and a String form.
@@ -36,7 +39,14 @@ public class LocalDateTimeStringConverter implements TypeConverter<LocalDateTime
             return null;
         }
 
-        return LocalDateTime.parse(str);
+        try
+        {
+            return LocalDateTime.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, LocalDateTime.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(LocalDateTime date)

--- a/src/main/java/org/datanucleus/store/types/converters/LocalTimeStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/LocalTimeStringConverter.java
@@ -18,9 +18,12 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter;
 import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.LocalTime and a String form.
@@ -36,7 +39,14 @@ public class LocalTimeStringConverter implements TypeConverter<LocalTime, String
             return null;
         }
 
-        return LocalTime.parse(str);
+        try
+        {
+            return LocalTime.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, LocalTime.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(LocalTime date)

--- a/src/main/java/org/datanucleus/store/types/converters/LongStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/LongStringConverter.java
@@ -17,6 +17,9 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.types.converters;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
+
 /**
  * Class to handle the conversion between java.lang.Long and a String form.
  */
@@ -37,7 +40,7 @@ public class LongStringConverter implements TypeConverter<Long, String>
         }
         catch (NumberFormatException nfe)
         {
-            return null;
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Long.class.getName()), nfe);
         }
     }
 
@@ -47,6 +50,6 @@ public class LongStringConverter implements TypeConverter<Long, String>
         {
             return null;
         }
-        return "" + val;
+        return val.toString();
     }
 }

--- a/src/main/java/org/datanucleus/store/types/converters/MonthDayStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/MonthDayStringConverter.java
@@ -18,8 +18,12 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.MonthDay and String.
@@ -35,7 +39,14 @@ public class MonthDayStringConverter implements TypeConverter<MonthDay, String>
             return null;
         }
 
-        return MonthDay.parse(str);
+        try
+        {
+            return MonthDay.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, MonthDay.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(MonthDay md)

--- a/src/main/java/org/datanucleus/store/types/converters/OffsetDateTimeStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/OffsetDateTimeStringConverter.java
@@ -18,9 +18,10 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 
-import org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter;
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.OffsetDateTime and a String form.
@@ -36,7 +37,14 @@ public class OffsetDateTimeStringConverter implements TypeConverter<OffsetDateTi
             return null;
         }
 
-        return OffsetDateTime.parse(str);
+        try
+        {
+            return OffsetDateTime.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, OffsetDateTime.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(OffsetDateTime date)

--- a/src/main/java/org/datanucleus/store/types/converters/OffsetTimeStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/OffsetTimeStringConverter.java
@@ -18,9 +18,10 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.OffsetTime;
+import java.time.format.DateTimeParseException;
 
-import org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter;
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.OffsetTime and a String form.
@@ -35,8 +36,14 @@ public class OffsetTimeStringConverter implements TypeConverter<OffsetTime, Stri
         {
             return null;
         }
-
-        return OffsetTime.parse(str);
+        try
+        {
+            return OffsetTime.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, OffsetTime.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(OffsetTime time)

--- a/src/main/java/org/datanucleus/store/types/converters/PeriodStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/PeriodStringConverter.java
@@ -18,8 +18,10 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.Period;
+import java.time.format.DateTimeParseException;
 
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.Period and a String form.
@@ -35,7 +37,14 @@ public class PeriodStringConverter implements TypeConverter<Period, String>
             return null;
         }
 
-        return Period.parse(str);
+        try
+        {
+            return Period.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Period.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(Period per)

--- a/src/main/java/org/datanucleus/store/types/converters/SqlDateStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/SqlDateStringConverter.java
@@ -19,6 +19,9 @@ package org.datanucleus.store.types.converters;
 
 import java.sql.Date;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
+
 /**
  * Class to handle the conversion between java.sql.Date and a String form.
  */
@@ -33,7 +36,14 @@ public class SqlDateStringConverter implements TypeConverter<Date, String>
             return null;
         }
 
-        return java.sql.Date.valueOf(str);
+        try
+        {
+            return java.sql.Date.valueOf(str);
+        }
+        catch (IllegalArgumentException iae)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Date.class.getName()), iae);
+        }
     }
 
     public String toDatastoreType(Date date)

--- a/src/main/java/org/datanucleus/store/types/converters/SqlTimeStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/SqlTimeStringConverter.java
@@ -19,6 +19,9 @@ package org.datanucleus.store.types.converters;
 
 import java.sql.Time;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
+
 /**
  * Class to handle the conversion between java.sql.Time and a String form.
  */
@@ -33,7 +36,14 @@ public class SqlTimeStringConverter implements TypeConverter<Time, String>
             return null;
         }
 
-        return java.sql.Time.valueOf(str);
+        try
+        {
+            return java.sql.Time.valueOf(str);
+        }
+        catch (IllegalArgumentException iae)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Time.class.getName()), iae);
+        }
     }
 
     public String toDatastoreType(Time time)

--- a/src/main/java/org/datanucleus/store/types/converters/SqlTimestampStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/SqlTimestampStringConverter.java
@@ -19,6 +19,9 @@ package org.datanucleus.store.types.converters;
 
 import java.sql.Timestamp;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
+
 /**
  * Class to handle the conversion between java.sql.Timestamp and a String form.
  */
@@ -33,7 +36,14 @@ public class SqlTimestampStringConverter implements TypeConverter<Timestamp, Str
             return null;
         }
 
-        return java.sql.Timestamp.valueOf(str);
+        try
+        {
+            return java.sql.Timestamp.valueOf(str);
+        }
+        catch (IllegalArgumentException iae)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Timestamp.class.getName()), iae);
+        }
     }
 
     public String toDatastoreType(Timestamp ts)

--- a/src/main/java/org/datanucleus/store/types/converters/URIStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/URIStringConverter.java
@@ -19,6 +19,8 @@ package org.datanucleus.store.types.converters;
 
 import java.net.URI;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 import org.datanucleus.util.StringUtils;
 
 /**
@@ -35,7 +37,14 @@ public class URIStringConverter implements TypeConverter<URI, String>
             return null;
         }
 
-        return java.net.URI.create(str.trim());
+        try
+        {
+            return java.net.URI.create(str.trim());
+        }
+        catch (IllegalArgumentException iae)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, URI.class.getName()), iae);
+        }
     }
 
     public String toDatastoreType(URI uri)

--- a/src/main/java/org/datanucleus/store/types/converters/URLStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/URLStringConverter.java
@@ -38,16 +38,14 @@ public class URLStringConverter implements TypeConverter<URL, String>
             return null;
         }
 
-        URL url = null;
         try
         {
-            url = new java.net.URL(str.trim());
+            return new java.net.URL(str.trim());
         }
         catch (MalformedURLException mue)
         {
             throw new NucleusDataStoreException(Localiser.msg("016002", str, URL.class.getName()), mue);
         }
-        return url;
     }
 
     public String toDatastoreType(URL url)

--- a/src/main/java/org/datanucleus/store/types/converters/UUIDStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/UUIDStringConverter.java
@@ -19,6 +19,8 @@ package org.datanucleus.store.types.converters;
 
 import java.util.UUID;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 import org.datanucleus.util.StringUtils;
 
 /**
@@ -35,7 +37,14 @@ public class UUIDStringConverter implements TypeConverter<UUID, String>, ColumnL
             return null;
         }
 
-        return UUID.fromString(str);
+        try
+        {
+            return UUID.fromString(str);
+        }
+        catch (IllegalArgumentException iae)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, UUID.class.getName()), iae);
+        }
     }
 
     public String toDatastoreType(UUID uuid)

--- a/src/main/java/org/datanucleus/store/types/converters/YearMonthStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/YearMonthStringConverter.java
@@ -18,8 +18,10 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.YearMonth and String.
@@ -35,7 +37,14 @@ public class YearMonthStringConverter implements TypeConverter<YearMonth, String
             return null;
         }
 
-        return YearMonth.parse(str);
+        try
+        {
+            return YearMonth.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, YearMonth.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(YearMonth ym)

--- a/src/main/java/org/datanucleus/store/types/converters/YearStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/YearStringConverter.java
@@ -18,8 +18,11 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.Year;
+import java.time.format.DateTimeParseException;
 
+import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.Year and String.
@@ -35,7 +38,14 @@ public class YearStringConverter implements TypeConverter<Year, String>
             return null;
         }
 
-        return Year.parse(str);
+        try
+        {
+            return Year.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, Year.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(Year year)

--- a/src/main/java/org/datanucleus/store/types/converters/ZoneIdStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/ZoneIdStringConverter.java
@@ -17,9 +17,11 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.types.converters;
 
+import java.time.DateTimeException;
 import java.time.ZoneId;
 
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.ZoneId and String.
@@ -35,7 +37,14 @@ public class ZoneIdStringConverter implements TypeConverter<ZoneId, String>
             return null;
         }
 
-        return ZoneId.of(str);
+        try
+        {
+            return ZoneId.of(str);
+        }
+        catch (DateTimeException dte)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, ZoneId.class.getName()), dte);
+        }
     }
 
     public String toDatastoreType(ZoneId zone)

--- a/src/main/java/org/datanucleus/store/types/converters/ZoneOffsetStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/ZoneOffsetStringConverter.java
@@ -17,9 +17,11 @@ Contributors:
 **********************************************************************/
 package org.datanucleus.store.types.converters;
 
+import java.time.DateTimeException;
 import java.time.ZoneOffset;
 
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.ZoneOffset and String.
@@ -35,7 +37,14 @@ public class ZoneOffsetStringConverter implements TypeConverter<ZoneOffset, Stri
             return null;
         }
 
-        return ZoneOffset.of(str);
+        try
+        {
+            return ZoneOffset.of(str);
+        }
+        catch (DateTimeException dte)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, ZoneOffset.class.getName()), dte);
+        }
     }
 
     public String toDatastoreType(ZoneOffset offset)

--- a/src/main/java/org/datanucleus/store/types/converters/ZonedDateTimeStringConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/ZonedDateTimeStringConverter.java
@@ -18,9 +18,10 @@ Contributors:
 package org.datanucleus.store.types.converters;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
-import org.datanucleus.store.types.converters.ColumnLengthDefiningTypeConverter;
-import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.exceptions.NucleusDataStoreException;
+import org.datanucleus.util.Localiser;
 
 /**
  * Class to handle the conversion between java.time.ZonedDateTime and a String form.
@@ -36,7 +37,14 @@ public class ZonedDateTimeStringConverter implements TypeConverter<ZonedDateTime
             return null;
         }
 
-        return ZonedDateTime.parse(str);
+        try
+        {
+            return ZonedDateTime.parse(str);
+        }
+        catch (DateTimeParseException pe)
+        {
+            throw new NucleusDataStoreException(Localiser.msg("016002", str, ZonedDateTime.class.getName()), pe);
+        }
     }
 
     public String toDatastoreType(ZonedDateTime date)


### PR DESCRIPTION
1. Some throw an Exception, some return null.  Synchronize on throwing an Exception
2. Replace SimpleDateFormat with Java 8 `DateTimeFormatter `
3. A few other nits to get all the converters to match