### PR TITLE
Wrap byte arrays instead of copy into ByteBuffer

### DIFF
--- a/src/main/java/org/datanucleus/store/types/converters/BigDecimalArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/BigDecimalArrayByteBufferConverter.java
@@ -40,9 +40,7 @@ public class BigDecimalArrayByteBufferConverter implements TypeConverter<BigDeci
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromBigDecimalArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/BigIntegerArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/BigIntegerArrayByteBufferConverter.java
@@ -40,9 +40,7 @@ public class BigIntegerArrayByteBufferConverter implements TypeConverter<BigInte
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromBigIntegerArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/BooleanArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/BooleanArrayByteBufferConverter.java
@@ -39,9 +39,7 @@ public class BooleanArrayByteBufferConverter implements TypeConverter<boolean[],
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromBooleanArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/CharArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/CharArrayByteBufferConverter.java
@@ -39,9 +39,7 @@ public class CharArrayByteBufferConverter implements TypeConverter<char[], ByteB
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromCharArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/DoubleArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/DoubleArrayByteBufferConverter.java
@@ -39,9 +39,7 @@ public class DoubleArrayByteBufferConverter implements TypeConverter<double[], B
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromDoubleArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/FloatArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/FloatArrayByteBufferConverter.java
@@ -39,9 +39,7 @@ public class FloatArrayByteBufferConverter implements TypeConverter<float[], Byt
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromFloatArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/IntArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/IntArrayByteBufferConverter.java
@@ -39,9 +39,7 @@ public class IntArrayByteBufferConverter implements TypeConverter<int[], ByteBuf
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromIntArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/datanucleus/store/types/converters/LongArrayByteBufferConverter.java
+++ b/src/main/java/org/datanucleus/store/types/converters/LongArrayByteBufferConverter.java
@@ -39,9 +39,7 @@ public class LongArrayByteBufferConverter implements TypeConverter<long[], ByteB
             return null;
         }
         byte[] bytes = TypeConversionHelper.getByteArrayFromLongArray(memberValue);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.put(bytes);
-        return byteBuffer;
+        return ByteBuffer.wrap(bytes);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
Wrap byte arrays in a ByteBuffer instead of copying the data in converters.

This is already the behavior in:

- BufferedImageByteBufferConverter
- SerializableByteBufferConverter
