### PR TITLE
Support for priority based type registration.

### DIFF
--- a/src/main/java/org/datanucleus/store/types/TypeManagerImpl.java
+++ b/src/main/java/org/datanucleus/store/types/TypeManagerImpl.java
@@ -116,7 +116,7 @@ import org.datanucleus.util.StringUtils;
  */
 public class TypeManagerImpl implements TypeManager, Serializable
 {
-    private static final long serialVersionUID = 8217508318434539002L;
+    private static final long serialVersionUID = -8715639980649093551L;
 
     protected NucleusContext nucCtx;
 
@@ -164,6 +164,7 @@ public class TypeManagerImpl implements TypeManager, Serializable
     {
         containerHandlersByClass = null;
         javaTypes = null;
+        javaTypePriorities = null;
 
         typeConverterByName.clear();
         typeConverterMap.clear();
@@ -1233,6 +1234,8 @@ public class TypeManagerImpl implements TypeManager, Serializable
                         javaTypeName += "<" + genericTypeName + ">";
                     }
 
+                    // Register entries for a java type based on the "priority" flag,
+                    // where higher priority is allowed to override lower priority. 
                     
                     boolean doRegister = !javaTypes.containsKey(javaTypeName);
                     if(!doRegister) {
@@ -1244,7 +1247,6 @@ public class TypeManagerImpl implements TypeManager, Serializable
                     
                     if (doRegister)
                     {
-                        // Only add first entry for a java type (ordered by the "priority" flag)
 
                         Class wrapperClass = loadClass(mgr, elems, i, wrapperType, "016005");
                         Class wrapperClassBacked = loadClass(mgr, elems, i, wrapperTypeBacked, "016005");
@@ -1259,7 +1261,7 @@ public class TypeManagerImpl implements TypeManager, Serializable
                         javaTypes.put(typeName, new JavaType(cls, genericType, embedded, dfg, wrapperClass, wrapperClassBacked, containerHandlerClass, typeConverterName));
 
                         // keep track of registered priority values, 
-                        // as an optimization, save heap usage, don't collect priority==0 
+                        // as an optimization, save heap usage, don't collect priority<=0 
                         if(priority>0) {
                             javaTypePriorities.put(javaTypeName, priority);
                         }

--- a/src/main/java/org/datanucleus/store/types/TypeManagerImpl.java
+++ b/src/main/java/org/datanucleus/store/types/TypeManagerImpl.java
@@ -116,7 +116,7 @@ import org.datanucleus.util.StringUtils;
  */
 public class TypeManagerImpl implements TypeManager, Serializable
 {
-    private static final long serialVersionUID = -8715639980649093551L;
+    private static final long serialVersionUID = 8217508318434539002L;
 
     protected NucleusContext nucCtx;
 
@@ -125,9 +125,6 @@ public class TypeManagerImpl implements TypeManager, Serializable
     /** Map of java types, keyed by the class name. */
     protected Map<String, JavaType> javaTypes = new ConcurrentHashMap<>();
     
-    /** Map of java type priorities, keyed by the class name. */
-    protected Map<String, Integer> javaTypePriorities = new ConcurrentHashMap<>();
-
     /** Map of ContainerHandlers, keyed by the container type class name. */
     protected Map<Class, ? super ContainerHandler> containerHandlersByClass = new ConcurrentHashMap<>();
 
@@ -164,7 +161,6 @@ public class TypeManagerImpl implements TypeManager, Serializable
     {
         containerHandlersByClass = null;
         javaTypes = null;
-        javaTypePriorities = null;
 
         typeConverterByName.clear();
         typeConverterMap.clear();
@@ -1162,6 +1158,9 @@ public class TypeManagerImpl implements TypeManager, Serializable
         addJavaType(Enum[].class, null, true, false, null, null, ArrayHandler.class, null);
         addJavaType(Object[].class, null, true, false, null, null, ArrayHandler.class, null);
 
+        // Map of java type priorities, keyed by the class name
+        final Map<String, Integer> javaTypePriorities = new HashMap<>();
+        
         // Add on any plugin mechanism types
         ConfigurationElement[] elems = mgr.getConfigurationElementsForExtension("org.datanucleus.java_type", null, null);
         if (elems != null)


### PR DESCRIPTION
Allows to override already registered built-in types using plugins, when explicitly declaring the **priority** attribute like in
```xml
<plugin ...>
    <extension point="org.datanucleus.java_type">
        <java-type
                name="java.time.ZonedDateTime"
                dfg="true"
                priority="10"
                converter-name="myConverter" />
    </extension>
</plugin>
```

For all built-in type handlers uses default `priority = 0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datanucleus/datanucleus-core/360)
<!-- Reviewable:end -->
