### PR TITLE
Overload MapStore.putAll with an optional cache delegate

### DIFF
--- a/src/main/java/org/datanucleus/store/types/scostore/MapStore.java
+++ b/src/main/java/org/datanucleus/store/types/scostore/MapStore.java
@@ -1,5 +1,5 @@
 /**********************************************************************
-Copyright (c) 2002 Mike Martin (TJDO) and others. All rights reserved. 
+Copyright (c) 2002 Mike Martin (TJDO) and others. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -10,7 +10,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License. 
+limitations under the License.
 
 Contributors:
 2003 Andy Jefferson - coding standards
@@ -55,14 +55,14 @@ public interface MapStore<K, V> extends Store
     boolean valuesAreSerialised();
 
     // -------------------------------- Map Methods ----------------------------
- 
+
     /**
      * Accessor for whether the Map contains this value.
      * @param op ObjectProvider for the owner of the map.
      * @param value The value to check
      * @return Whether it is contained.
      */
-    boolean containsValue(ObjectProvider op, Object value);
+    boolean containsValue(ObjectProvider<?> op, Object value);
 
     /**
      * Accessor for whether the Map contains this key.
@@ -70,72 +70,84 @@ public interface MapStore<K, V> extends Store
      * @param key The key to check
      * @return Whether it is contained.
      */
-    boolean containsKey(ObjectProvider op, Object key);
+    boolean containsKey(ObjectProvider<?> op, Object key);
 
     /**
      * Accessor for a value from the Map.
-     * @param op ObjectProvider for the owner of the map. 
+     * @param op ObjectProvider for the owner of the map.
      * @param key Key for the value.
      * @return Value for this key.
      */
-    V get(ObjectProvider op, Object key);
+    V get(ObjectProvider<?> op, Object key);
 
     /**
      * Method to add a value to the Map against this key.
-     * @param op ObjectProvider for the owner of the map. 
+     * @param op ObjectProvider for the owner of the map.
      * @param key The key.
      * @param value The value.
      * @return Value that was previously against this key.
      */
-    V put(ObjectProvider op, K key, V value);
+    V put(ObjectProvider<?> op, K key, V value);
 
     /**
      * Method to add a map of values to the Map.
-     * @param op ObjectProvider for the owner of the map. 
+     * @param op ObjectProvider for the owner of the map.
      * @param m The map to add.
-     */ 
-    void putAll(ObjectProvider op, Map<? extends K, ? extends V> m);
+     */
+    void putAll(ObjectProvider<?> op, Map<? extends K, ? extends V> m);
+
+    /**
+     * Method to add a map of values to the Map.
+     * @param op ObjectProvider for the owner of the map.
+     * @param m The map to add.
+     * @param cachedDelegate The known cached entries in map before the putAll operation. null means entries
+     * of map is unknown.
+     */
+    default void putAll(ObjectProvider<?> op, Map<? extends K, ? extends V> m, Map<K, V> delegate)
+    {
+        putAll(op, m);
+    }
 
     /**
      * Method to remove a value from the Map.
-     * @param op ObjectProvider for the owner of the map. 
+     * @param op ObjectProvider for the owner of the map.
      * @param key Key whose value is to be removed.
      * @return Value that was removed.
      */
-    V remove(ObjectProvider op, Object key);
+    V remove(ObjectProvider<?> op, Object key);
 
     /**
      * Method to remove a value from the Map.
-     * @param op ObjectProvider for the owner of the map. 
+     * @param op ObjectProvider for the owner of the map.
      * @param key Key whose value is to be removed.
      * @param val Value for this key when the value is known (to save the lookup)
      * @return Value that was removed.
      */
-    V remove(ObjectProvider op, Object key, Object val);
+    V remove(ObjectProvider<?> op, Object key, Object val);
 
     /**
      * Method to clear the map.
-     * @param op ObjectProvider for the owner of the map. 
+     * @param op ObjectProvider for the owner of the map.
      */
-    void clear(ObjectProvider op);
+    void clear(ObjectProvider<?> op);
 
     /**
      * Accessor for a backing store representing the key set for the Map.
      * @return Keys for the Map.
      */
-    SetStore keySetStore();
+    SetStore<K> keySetStore();
 
     /**
      * Accessor for a backing store representing the values in the Map.
      * @return Values for the Map.
      */
-    CollectionStore valueCollectionStore();
+    CollectionStore<V> valueCollectionStore();
 
     /**
      * Accessor for a backing store representing the entry set for the Map.
      * @return Entry set for the Map.
      */
-    SetStore entrySetStore();
+    SetStore<Map.Entry<K, V>> entrySetStore();
 
     /**
      * Method to update an embedded key in the map.
@@ -145,7 +157,7 @@ public interface MapStore<K, V> extends Store
      * @param newValue The new value for the field
      * @return Whether the element was modified
      */
-    boolean updateEmbeddedKey(ObjectProvider op, Object key, int fieldNumber, Object newValue);
+    boolean updateEmbeddedKey(ObjectProvider<?> op, Object key, int fieldNumber, Object newValue);
 
     /**
      * Method to update an embedded value in the map.
@@ -155,5 +167,5 @@ public interface MapStore<K, V> extends Store
      * @param newValue The new value for the field
      * @return Whether the element was modified
      */
-    boolean updateEmbeddedValue(ObjectProvider op, Object value, int fieldNumber, Object newValue);
+    boolean updateEmbeddedValue(ObjectProvider<?> op, Object value, int fieldNumber, Object newValue);
 }

--- a/src/main/java/org/datanucleus/store/types/wrappers/backed/HashMap.java
+++ b/src/main/java/org/datanucleus/store/types/wrappers/backed/HashMap.java
@@ -20,6 +20,7 @@ package org.datanucleus.store.types.wrappers.backed;
 
 import java.io.ObjectStreamException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
@@ -46,9 +47,12 @@ import org.datanucleus.util.NucleusLogger;
 public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<K, V> implements BackedSCO
 {
     protected transient boolean allowNulls = true;
+
     protected transient MapStore<K, V> backingStore;
-    protected transient boolean useCache=true;
-    protected transient boolean isCacheLoaded=false;
+
+    protected transient boolean useCache = true;
+
+    protected transient boolean isCacheLoaded = false;
 
     /**
      * Constructor
@@ -66,16 +70,18 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
 
         if (!SCOUtils.mapHasSerialisedKeysAndValues(mmd) && mmd.getPersistenceModifier() == FieldPersistenceModifier.PERSISTENT)
         {
-            this.backingStore = (MapStore)((BackedSCOStoreManager)ownerOP.getStoreManager()).getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), 
-                mmd, java.util.HashMap.class);
+            this.backingStore = (MapStore) ((BackedSCOStoreManager) ownerOP.getStoreManager())
+                    .getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), mmd, java.util.HashMap.class);
         }
 
         if (NucleusLogger.PERSISTENCE.isDebugEnabled())
         {
-            NucleusLogger.PERSISTENCE.debug(SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
+            NucleusLogger.PERSISTENCE.debug(
+                SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
         }
     }
 
+    @Override
     public void initialise(java.util.HashMap newValue, Object oldValue)
     {
         if (newValue != null)
@@ -87,7 +93,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                 Iterator iter = newValue.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -95,7 +101,8 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                         ObjectProvider keyOP = ec.findObjectProvider(key);
                         if (keyOP == null)
                         {
-                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -103,7 +110,8 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                         ObjectProvider valOP = ec.findObjectProvider(value);
                         if (valOP == null)
                         {
-                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -117,7 +125,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
             if (useCache)
             {
                 // Load up old values into delegate as starting point
-                java.util.Map oldMap = (java.util.Map)oldValue;
+                java.util.Map oldMap = (java.util.Map) oldValue;
                 if (oldMap != null)
                 {
                     delegate.putAll(oldMap);
@@ -133,7 +141,8 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                 {
                     if (SCOUtils.useQueuedUpdate(ownerOP))
                     {
-                        // If not yet flushed to store then no need to add to queue (since will be handled via insert)
+                        // If not yet flushed to store then no need to add to queue (since will be handled via
+                        // insert)
                         if (ownerOP.isFlushedToDatastore() || !ownerOP.getLifecycleState().isNew())
                         {
                             ownerOP.getExecutionContext().addOperationToQueue(new MapClearOperation(ownerOP, backingStore));
@@ -141,7 +150,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                             Iterator iter = newValue.entrySet().iterator();
                             while (iter.hasNext())
                             {
-                                java.util.Map.Entry entry = (java.util.Map.Entry)iter.next();
+                                java.util.Map.Entry entry = (java.util.Map.Entry) iter.next();
                                 ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                             }
                         }
@@ -149,7 +158,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                     else
                     {
                         backingStore.clear(ownerOP);
-                        backingStore.putAll(ownerOP, newValue);
+                        backingStore.putAll(ownerOP, newValue, Collections.emptyMap());
                     }
                 }
                 delegate.putAll(newValue);
@@ -163,6 +172,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Method to initialise the SCO from an existing value.
      * @param m Object to set value using.
      */
+    @Override
     public void initialise(java.util.HashMap m)
     {
         if (m != null)
@@ -174,7 +184,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -182,7 +192,8 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                         ObjectProvider keyOP = ec.findObjectProvider(key);
                         if (keyOP == null)
                         {
-                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -190,7 +201,8 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                         ObjectProvider valOP = ec.findObjectProvider(value);
                         if (valOP == null)
                         {
-                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -209,6 +221,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     /**
      * Method to initialise the SCO for use.
      */
+    @Override
     public void initialise()
     {
         if (useCache && !SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd))
@@ -222,6 +235,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Accessor for the unwrapped value that we are wrapping.
      * @return The unwrapped value
      */
+    @Override
     public java.util.HashMap getValue()
     {
         loadFromStore();
@@ -229,9 +243,10 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     }
 
     /**
-     * Method to effect the load of the data in the SCO.
-     * Used when the SCO supports lazy-loading to tell it to load all now.
+     * Method to effect the load of the data in the SCO. Used when the SCO supports lazy-loading to tell it to
+     * load all now.
      */
+    @Override
     public void load()
     {
         if (useCache)
@@ -241,10 +256,11 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     }
 
     /**
-     * Method to return if the SCO has its contents loaded.
-     * If the SCO doesn't support lazy loading will just return true.
+     * Method to return if the SCO has its contents loaded. If the SCO doesn't support lazy loading will just
+     * return true.
      * @return Whether it is loaded
      */
+    @Override
     public boolean isLoaded()
     {
         return useCache ? isCacheLoaded : false;
@@ -270,9 +286,11 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.datanucleus.store.types.backed.BackedSCO#getBackingStore()
      */
+    @Override
     public Store getBackingStore()
     {
         return backingStore;
@@ -285,6 +303,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedKey(K key, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -300,6 +319,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedValue(V value, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -311,6 +331,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     /**
      * Method to unset the owner and field details.
      */
+    @Override
     public void unsetOwner()
     {
         super.unsetOwner();
@@ -321,13 +342,16 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     }
 
     // ------------------ Implementation of HashMap methods --------------------
- 
+
     /**
      * Creates and returns a copy of this object.
-     * <P>Mutable second-class Objects are required to provide a public clone method in order to allow for copying persistable objects.
-     * In contrast to Object.clone(), this method must not throw a CloneNotSupportedException.
+     * <P>
+     * Mutable second-class Objects are required to provide a public clone method in order to allow for
+     * copying persistable objects. In contrast to Object.clone(), this method must not throw a
+     * CloneNotSupportedException.
      * @return The cloned object
      */
+    @Override
     public Object clone()
     {
         if (useCache)
@@ -343,6 +367,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * @param key The key
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsKey(Object key)
     {
         if (useCache && isCacheLoaded)
@@ -363,6 +388,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * @param value The value
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsValue(Object value)
     {
         if (useCache && isCacheLoaded)
@@ -382,6 +408,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Accessor for the set of entries in the Map.
      * @return Set of entries
      **/
+    @Override
     public java.util.Set entrySet()
     {
         if (useCache)
@@ -396,6 +423,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
         return delegate.entrySet();
     }
 
+    @Override
     public boolean equals(Object o)
     {
         if (useCache)
@@ -411,7 +439,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
         {
             return false;
         }
-        java.util.Map m = (java.util.Map)o;
+        java.util.Map m = (java.util.Map) o;
 
         return entrySet().equals(m.entrySet());
     }
@@ -443,6 +471,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * @param key The key
      * @return The value.
      **/
+    @Override
     public V get(Object key)
     {
         if (useCache)
@@ -457,6 +486,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
         return delegate.get(key);
     }
 
+    @Override
     public int hashCode()
     {
         if (useCache)
@@ -481,6 +511,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Method to return if the Map is empty.
      * @return Whether it is empty.
      **/
+    @Override
     public boolean isEmpty()
     {
         return size() == 0;
@@ -490,6 +521,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Accessor for the set of keys in the Map.
      * @return Set of keys.
      **/
+    @Override
     public java.util.Set keySet()
     {
         if (useCache)
@@ -508,6 +540,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Method to return the size of the Map.
      * @return The size
      **/
+    @Override
     public int size()
     {
         if (useCache && isCacheLoaded)
@@ -527,6 +560,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Accessor for the set of values in the Map.
      * @return Set of values.
      **/
+    @Override
     public Collection values()
     {
         if (useCache)
@@ -542,10 +576,11 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     }
 
     // --------------------------- Mutator methods -----------------------------
- 
+
     /**
      * Method to clear the HashMap.
      **/
+    @Override
     public void clear()
     {
         makeDirty();
@@ -568,13 +603,14 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
             ownerOP.getExecutionContext().processNontransactionalUpdate();
         }
     }
- 
+
     /**
      * Method to add a value against a key to the HashMap.
      * @param key The key
      * @param value The value
      * @return The previous value for the specified key.
      **/
+    @Override
     public V put(K key, V value)
     {
         // Reject inappropriate values
@@ -631,6 +667,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * Method to add the specified Map's values under their keys here.
      * @param m The map
      **/
+    @Override
     public void putAll(java.util.Map m)
     {
         makeDirty();
@@ -648,13 +685,13 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                 }
             }
             else
             {
-                backingStore.putAll(ownerOP, m);
+                backingStore.putAll(ownerOP, m, useCache ? Collections.unmodifiableMap(delegate) : null);
             }
         }
         delegate.putAll(m);
@@ -670,6 +707,7 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
      * @param key The key to remove
      * @return The value that was removed from this key.
      **/
+    @Override
     public V remove(Object key)
     {
         makeDirty();
@@ -707,18 +745,16 @@ public class HashMap<K, V> extends org.datanucleus.store.types.wrappers.HashMap<
     }
 
     /**
-     * The writeReplace method is called when ObjectOutputStream is preparing
-     * to write the object to the stream. The ObjectOutputStream checks whether
-     * the class defines the writeReplace method. If the method is defined, the
-     * writeReplace method is called to allow the object to designate its
-     * replacement in the stream. The object returned should be either of the
-     * same type as the object passed in or an object that when read and
-     * resolved will result in an object of a type that is compatible with all
-     * references to the object.
-     * 
+     * The writeReplace method is called when ObjectOutputStream is preparing to write the object to the
+     * stream. The ObjectOutputStream checks whether the class defines the writeReplace method. If the method
+     * is defined, the writeReplace method is called to allow the object to designate its replacement in the
+     * stream. The object returned should be either of the same type as the object passed in or an object that
+     * when read and resolved will result in an object of a type that is compatible with all references to the
+     * object.
      * @return the replaced object
      * @throws ObjectStreamException if an error occurs
      */
+    @Override
     protected Object writeReplace() throws ObjectStreamException
     {
         if (useCache)

--- a/src/main/java/org/datanucleus/store/types/wrappers/backed/Hashtable.java
+++ b/src/main/java/org/datanucleus/store/types/wrappers/backed/Hashtable.java
@@ -19,6 +19,7 @@ package org.datanucleus.store.types.wrappers.backed;
 
 import java.io.ObjectStreamException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
@@ -45,8 +46,11 @@ import org.datanucleus.util.NucleusLogger;
 public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashtable<K, V> implements BackedSCO
 {
     protected transient MapStore<K, V> backingStore;
+
     protected transient boolean allowNulls = false;
+
     protected transient boolean useCache = true;
+
     protected transient boolean isCacheLoaded = false;
 
     /**
@@ -64,16 +68,18 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
 
         if (!SCOUtils.mapHasSerialisedKeysAndValues(mmd) && mmd.getPersistenceModifier() == FieldPersistenceModifier.PERSISTENT)
         {
-            this.backingStore = (MapStore)((BackedSCOStoreManager)ownerOP.getStoreManager()).getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), 
-                mmd, java.util.Hashtable.class);
+            this.backingStore = (MapStore) ((BackedSCOStoreManager) ownerOP.getStoreManager())
+                    .getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), mmd, java.util.Hashtable.class);
         }
 
         if (NucleusLogger.PERSISTENCE.isDebugEnabled())
         {
-            NucleusLogger.PERSISTENCE.debug(SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
+            NucleusLogger.PERSISTENCE.debug(
+                SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
         }
     }
 
+    @Override
     public void initialise(java.util.Hashtable newValue, Object oldValue)
     {
         if (newValue != null)
@@ -85,7 +91,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                 Iterator iter = newValue.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -93,7 +99,8 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                         ObjectProvider keyOP = ec.findObjectProvider(key);
                         if (keyOP == null)
                         {
-                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -101,7 +108,8 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                         ObjectProvider valOP = ec.findObjectProvider(value);
                         if (valOP == null)
                         {
-                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -115,7 +123,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
             if (useCache)
             {
                 // Load up old values into delegate as starting point
-                java.util.Map oldMap = (java.util.Map)oldValue;
+                java.util.Map oldMap = (java.util.Map) oldValue;
                 if (oldMap != null)
                 {
                     delegate.putAll(oldMap);
@@ -131,7 +139,8 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                 {
                     if (SCOUtils.useQueuedUpdate(ownerOP))
                     {
-                        // If not yet flushed to store then no need to add to queue (since will be handled via insert)
+                        // If not yet flushed to store then no need to add to queue (since will be handled via
+                        // insert)
                         if (ownerOP.isFlushedToDatastore() || !ownerOP.getLifecycleState().isNew())
                         {
                             ownerOP.getExecutionContext().addOperationToQueue(new MapClearOperation(ownerOP, backingStore));
@@ -139,7 +148,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                             Iterator iter = newValue.entrySet().iterator();
                             while (iter.hasNext())
                             {
-                                java.util.Map.Entry entry = (java.util.Map.Entry)iter.next();
+                                java.util.Map.Entry entry = (java.util.Map.Entry) iter.next();
                                 ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                             }
                         }
@@ -147,7 +156,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                     else
                     {
                         backingStore.clear(ownerOP);
-                        backingStore.putAll(ownerOP, newValue);
+                        backingStore.putAll(ownerOP, newValue, Collections.emptyMap());
                     }
                 }
                 delegate.putAll(newValue);
@@ -161,6 +170,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Method to initialise the SCO from an existing value.
      * @param m Object to set value using.
      */
+    @Override
     public void initialise(java.util.Hashtable m)
     {
         if (m != null)
@@ -172,7 +182,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -180,7 +190,8 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                         ObjectProvider keyOP = ec.findObjectProvider(key);
                         if (keyOP == null)
                         {
-                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -188,7 +199,8 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                         ObjectProvider valOP = ec.findObjectProvider(value);
                         if (valOP == null)
                         {
-                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -207,6 +219,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     /**
      * Method to initialise the SCO for use.
      */
+    @Override
     public void initialise()
     {
         if (useCache && !SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd))
@@ -220,6 +233,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Accessor for the unwrapped value that we are wrapping.
      * @return The unwrapped value
      */
+    @Override
     public java.util.Hashtable getValue()
     {
         loadFromStore();
@@ -227,9 +241,10 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     }
 
     /**
-     * Method to effect the load of the data in the SCO.
-     * Used when the SCO supports lazy-loading to tell it to load all now.
+     * Method to effect the load of the data in the SCO. Used when the SCO supports lazy-loading to tell it to
+     * load all now.
      */
+    @Override
     public void load()
     {
         if (useCache)
@@ -239,10 +254,11 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     }
 
     /**
-     * Method to return if the SCO has its contents loaded.
-     * If the SCO doesn't support lazy loading will just return true.
+     * Method to return if the SCO has its contents loaded. If the SCO doesn't support lazy loading will just
+     * return true.
      * @return Whether it is loaded
      */
+    @Override
     public boolean isLoaded()
     {
         return useCache ? isCacheLoaded : false;
@@ -268,9 +284,11 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.datanucleus.store.types.backed.BackedSCO#getBackingStore()
      */
+    @Override
     public Store getBackingStore()
     {
         return backingStore;
@@ -283,6 +301,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedKey(K key, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -298,6 +317,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedValue(V value, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -309,6 +329,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     /**
      * Method to unset the owner and field details.
      */
+    @Override
     public void unsetOwner()
     {
         if (backingStore != null)
@@ -318,13 +339,16 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     }
 
     // ------------------ Implementation of Hashtable methods ------------------
- 
+
     /**
      * Creates and returns a copy of this object.
-     * <P>Mutable second-class Objects are required to provide a public clone method in order to allow for copying persistable objects.
-     * In contrast to Object.clone(), this method must not throw a CloneNotSupportedException.
+     * <P>
+     * Mutable second-class Objects are required to provide a public clone method in order to allow for
+     * copying persistable objects. In contrast to Object.clone(), this method must not throw a
+     * CloneNotSupportedException.
      * @return The cloned object
      */
+    @Override
     public synchronized Object clone()
     {
         if (useCache)
@@ -340,6 +364,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param key The key
      * @return Whether it is contained
      **/
+    @Override
     public synchronized boolean containsKey(Object key)
     {
         if (useCache && isCacheLoaded)
@@ -360,6 +385,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param value The value
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsValue(Object value)
     {
         if (useCache && isCacheLoaded)
@@ -379,6 +405,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Accessor for the set of entries in the Map.
      * @return Set of entries
      **/
+    @Override
     public java.util.Set entrySet()
     {
         if (useCache)
@@ -398,6 +425,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param o The map to compare against.
      * @return Whether they are equal.
      **/
+    @Override
     public synchronized boolean equals(Object o)
     {
         if (useCache)
@@ -413,7 +441,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
         {
             return false;
         }
-        java.util.Map m = (java.util.Map)o;
+        java.util.Map m = (java.util.Map) o;
 
         return entrySet().equals(m.entrySet());
     }
@@ -445,6 +473,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param key The key
      * @return The value.
      **/
+    @Override
     public synchronized V get(Object key)
     {
         if (useCache)
@@ -463,6 +492,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Method to generate a hashcode for this Map.
      * @return The hashcode.
      **/
+    @Override
     public synchronized int hashCode()
     {
         if (useCache)
@@ -487,6 +517,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Method to return if the Map is empty.
      * @return Whether it is empty.
      **/
+    @Override
     public synchronized boolean isEmpty()
     {
         return size() == 0;
@@ -496,6 +527,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Accessor for the set of keys in the Map.
      * @return Set of keys.
      **/
+    @Override
     public java.util.Set keySet()
     {
         if (useCache)
@@ -514,6 +546,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Method to return the size of the Map.
      * @return The size
      **/
+    @Override
     public synchronized int size()
     {
         if (useCache && isCacheLoaded)
@@ -533,6 +566,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Accessor for the set of values in the Map.
      * @return Set of values.
      **/
+    @Override
     public Collection values()
     {
         if (useCache)
@@ -548,10 +582,11 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     }
 
     // -------------------------------- Mutator methods ------------------------
- 
+
     /**
      * Method to clear the Hashtable
      **/
+    @Override
     public synchronized void clear()
     {
         makeDirty();
@@ -581,6 +616,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param value The value
      * @return The previous value for the specified key.
      **/
+    @Override
     public synchronized V put(K key, V value)
     {
         // Reject inappropriate values
@@ -637,6 +673,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * Method to add the specified Map's values under their keys here.
      * @param m The map
      **/
+    @Override
     public synchronized void putAll(java.util.Map m)
     {
         makeDirty();
@@ -654,13 +691,13 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                 }
             }
             else
             {
-                backingStore.putAll(ownerOP, m);
+                backingStore.putAll(ownerOP, m, useCache ? Collections.unmodifiableMap(delegate) : null);
             }
         }
         delegate.putAll(m);
@@ -676,6 +713,7 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
      * @param key The key to remove
      * @return The value that was removed from this key.
      **/
+    @Override
     public synchronized V remove(Object key)
     {
         makeDirty();
@@ -713,18 +751,16 @@ public class Hashtable<K, V> extends org.datanucleus.store.types.wrappers.Hashta
     }
 
     /**
-     * The writeReplace method is called when ObjectOutputStream is preparing
-     * to write the object to the stream. The ObjectOutputStream checks whether
-     * the class defines the writeReplace method. If the method is defined, the
-     * writeReplace method is called to allow the object to designate its
-     * replacement in the stream. The object returned should be either of the
-     * same type as the object passed in or an object that when read and 
-     * resolved will result in an object of a type that is compatible with all
-     * references to the object.
-     * 
+     * The writeReplace method is called when ObjectOutputStream is preparing to write the object to the
+     * stream. The ObjectOutputStream checks whether the class defines the writeReplace method. If the method
+     * is defined, the writeReplace method is called to allow the object to designate its replacement in the
+     * stream. The object returned should be either of the same type as the object passed in or an object that
+     * when read and resolved will result in an object of a type that is compatible with all references to the
+     * object.
      * @return the replaced object
      * @throws ObjectStreamException if an error occurs
      */
+    @Override
     protected Object writeReplace() throws ObjectStreamException
     {
         if (useCache)

--- a/src/main/java/org/datanucleus/store/types/wrappers/backed/LinkedHashMap.java
+++ b/src/main/java/org/datanucleus/store/types/wrappers/backed/LinkedHashMap.java
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- 
+
 
 Contributors:
     ...
@@ -20,6 +20,7 @@ package org.datanucleus.store.types.wrappers.backed;
 
 import java.io.ObjectStreamException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
@@ -46,9 +47,12 @@ import org.datanucleus.util.NucleusLogger;
 public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.LinkedHashMap<K, V> implements BackedSCO
 {
     protected transient boolean allowNulls = true;
+
     protected transient MapStore<K, V> backingStore;
-    protected transient boolean useCache=true;
-    protected transient boolean isCacheLoaded=false;
+
+    protected transient boolean useCache = true;
+
+    protected transient boolean isCacheLoaded = false;
 
     /**
      * Constructor
@@ -66,16 +70,18 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
 
         if (!SCOUtils.mapHasSerialisedKeysAndValues(mmd) && mmd.getPersistenceModifier() == FieldPersistenceModifier.PERSISTENT)
         {
-            this.backingStore = (MapStore)((BackedSCOStoreManager)ownerOP.getStoreManager()).getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), 
-                mmd, java.util.LinkedHashMap.class);
+            this.backingStore = (MapStore) ((BackedSCOStoreManager) ownerOP.getStoreManager())
+                    .getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), mmd, java.util.LinkedHashMap.class);
         }
 
         if (NucleusLogger.PERSISTENCE.isDebugEnabled())
         {
-            NucleusLogger.PERSISTENCE.debug(SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
+            NucleusLogger.PERSISTENCE.debug(
+                SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
         }
     }
 
+    @Override
     public void initialise(java.util.LinkedHashMap newValue, Object oldValue)
     {
         if (newValue != null)
@@ -87,7 +93,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                 Iterator iter = newValue.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -95,7 +101,8 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                         ObjectProvider keyOP = ec.findObjectProvider(key);
                         if (keyOP == null)
                         {
-                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -103,7 +110,8 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                         ObjectProvider valOP = ec.findObjectProvider(value);
                         if (valOP == null)
                         {
-                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -117,7 +125,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
             if (useCache)
             {
                 // Load up old values into delegate as starting point
-                java.util.Map oldMap = (java.util.Map)oldValue;
+                java.util.Map oldMap = (java.util.Map) oldValue;
                 if (oldMap != null)
                 {
                     delegate.putAll(oldMap);
@@ -133,7 +141,8 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                 {
                     if (SCOUtils.useQueuedUpdate(ownerOP))
                     {
-                        // If not yet flushed to store then no need to add to queue (since will be handled via insert)
+                        // If not yet flushed to store then no need to add to queue (since will be handled via
+                        // insert)
                         if (ownerOP.isFlushedToDatastore() || !ownerOP.getLifecycleState().isNew())
                         {
                             ownerOP.getExecutionContext().addOperationToQueue(new MapClearOperation(ownerOP, backingStore));
@@ -141,7 +150,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                             Iterator iter = newValue.entrySet().iterator();
                             while (iter.hasNext())
                             {
-                                java.util.Map.Entry entry = (java.util.Map.Entry)iter.next();
+                                java.util.Map.Entry entry = (java.util.Map.Entry) iter.next();
                                 ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                             }
                         }
@@ -149,7 +158,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                     else
                     {
                         backingStore.clear(ownerOP);
-                        backingStore.putAll(ownerOP, newValue);
+                        backingStore.putAll(ownerOP, newValue, Collections.emptyMap());
                     }
                 }
                 delegate.putAll(newValue);
@@ -163,6 +172,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Method to initialise the SCO from an existing value.
      * @param m Object to set value using.
      */
+    @Override
     public void initialise(java.util.LinkedHashMap m)
     {
         if (m != null)
@@ -174,7 +184,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -182,7 +192,8 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                         ObjectProvider keyOP = ec.findObjectProvider(key);
                         if (keyOP == null)
                         {
-                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            keyOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -190,7 +201,8 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                         ObjectProvider valOP = ec.findObjectProvider(value);
                         if (valOP == null)
                         {
-                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            valOP = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -209,6 +221,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     /**
      * Method to initialise the SCO for use.
      */
+    @Override
     public void initialise()
     {
         if (useCache && !SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd))
@@ -222,6 +235,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Accessor for the unwrapped value that we are wrapping.
      * @return The unwrapped value
      */
+    @Override
     public java.util.LinkedHashMap getValue()
     {
         loadFromStore();
@@ -229,9 +243,10 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     }
 
     /**
-     * Method to effect the load of the data in the SCO.
-     * Used when the SCO supports lazy-loading to tell it to load all now.
+     * Method to effect the load of the data in the SCO. Used when the SCO supports lazy-loading to tell it to
+     * load all now.
      */
+    @Override
     public void load()
     {
         if (useCache)
@@ -241,10 +256,11 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     }
 
     /**
-     * Method to return if the SCO has its contents loaded.
-     * If the SCO doesn't support lazy loading will just return true.
+     * Method to return if the SCO has its contents loaded. If the SCO doesn't support lazy loading will just
+     * return true.
      * @return Whether it is loaded
      */
+    @Override
     public boolean isLoaded()
     {
         return useCache ? isCacheLoaded : false;
@@ -259,8 +275,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
         {
             if (NucleusLogger.PERSISTENCE.isDebugEnabled())
             {
-                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", 
-                    ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
+                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
             }
             delegate.clear();
 
@@ -271,9 +286,11 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.datanucleus.store.types.backed.BackedSCO#getBackingStore()
      */
+    @Override
     public Store getBackingStore()
     {
         return backingStore;
@@ -286,6 +303,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedKey(K key, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -301,6 +319,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedValue(V value, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -312,6 +331,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     /**
      * Method to unset the owner and field details.
      */
+    @Override
     public void unsetOwner()
     {
         super.unsetOwner();
@@ -322,13 +342,16 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     }
 
     // ------------------ Implementation of LinkedHashMap methods --------------------
- 
+
     /**
      * Creates and returns a copy of this object.
-     * <P>Mutable second-class Objects are required to provide a public clone method in order to allow for copying persistable objects.
-     * In contrast to Object.clone(), this method must not throw a CloneNotSupportedException.
+     * <P>
+     * Mutable second-class Objects are required to provide a public clone method in order to allow for
+     * copying persistable objects. In contrast to Object.clone(), this method must not throw a
+     * CloneNotSupportedException.
      * @return The cloned object
      */
+    @Override
     public Object clone()
     {
         if (useCache)
@@ -344,6 +367,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param key The key
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsKey(Object key)
     {
         if (useCache && isCacheLoaded)
@@ -364,6 +388,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param value The value
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsValue(Object value)
     {
         if (useCache && isCacheLoaded)
@@ -383,6 +408,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Accessor for the set of entries in the Map.
      * @return Set of entries
      **/
+    @Override
     public java.util.Set entrySet()
     {
         if (useCache)
@@ -402,6 +428,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param o The map to compare against.
      * @return Whether they are equal.
      **/
+    @Override
     public boolean equals(Object o)
     {
         if (useCache)
@@ -417,7 +444,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
         {
             return false;
         }
-        java.util.Map m = (java.util.Map)o;
+        java.util.Map m = (java.util.Map) o;
 
         return entrySet().equals(m.entrySet());
     }
@@ -449,6 +476,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param key The key
      * @return The value.
      **/
+    @Override
     public V get(Object key)
     {
         if (useCache)
@@ -467,6 +495,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Method to generate a hashcode for this Map.
      * @return The hashcode.
      **/
+    @Override
     public int hashCode()
     {
         if (useCache)
@@ -491,6 +520,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Method to return if the Map is empty.
      * @return Whether it is empty.
      **/
+    @Override
     public boolean isEmpty()
     {
         return size() == 0;
@@ -500,6 +530,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Accessor for the set of keys in the Map.
      * @return Set of keys.
      **/
+    @Override
     public java.util.Set keySet()
     {
         if (useCache)
@@ -518,6 +549,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Method to return the size of the Map.
      * @return The size
      **/
+    @Override
     public int size()
     {
         if (useCache && isCacheLoaded)
@@ -537,6 +569,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Accessor for the set of values in the Map.
      * @return Set of values.
      **/
+    @Override
     public Collection values()
     {
         if (useCache)
@@ -552,10 +585,11 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     }
 
     // --------------------------- Mutator methods -----------------------------
- 
+
     /**
      * Method to clear the LinkedHashMap.
      **/
+    @Override
     public void clear()
     {
         makeDirty();
@@ -578,13 +612,14 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
             ownerOP.getExecutionContext().processNontransactionalUpdate();
         }
     }
- 
+
     /**
      * Method to add a value against a key to the LinkedHashMap.
      * @param key The key
      * @param value The value
      * @return The previous value for the specified key.
      */
+    @Override
     public V put(K key, V value)
     {
         // Reject inappropriate values
@@ -641,6 +676,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * Method to add the specified Map's values under their keys here.
      * @param m The map
      **/
+    @Override
     public void putAll(java.util.Map m)
     {
         makeDirty();
@@ -658,13 +694,13 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                 }
             }
             else
             {
-                backingStore.putAll(ownerOP, m);
+                backingStore.putAll(ownerOP, m, useCache ? Collections.unmodifiableMap(delegate) : null);
             }
         }
         delegate.putAll(m);
@@ -680,6 +716,7 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
      * @param key The key to remove
      * @return The value that was removed from this key.
      **/
+    @Override
     public V remove(Object key)
     {
         makeDirty();
@@ -717,18 +754,16 @@ public class LinkedHashMap<K, V> extends org.datanucleus.store.types.wrappers.Li
     }
 
     /**
-     * The writeReplace method is called when ObjectOutputStream is preparing
-     * to write the object to the stream. The ObjectOutputStream checks whether
-     * the class defines the writeReplace method. If the method is defined, the
-     * writeReplace method is called to allow the object to designate its
-     * replacement in the stream. The object returned should be either of the
-     * same type as the object passed in or an object that when read and
-     * resolved will result in an object of a type that is compatible with all
-     * references to the object.
-     * 
+     * The writeReplace method is called when ObjectOutputStream is preparing to write the object to the
+     * stream. The ObjectOutputStream checks whether the class defines the writeReplace method. If the method
+     * is defined, the writeReplace method is called to allow the object to designate its replacement in the
+     * stream. The object returned should be either of the same type as the object passed in or an object that
+     * when read and resolved will result in an object of a type that is compatible with all references to the
+     * object.
      * @return the replaced object
      * @throws ObjectStreamException if an error occurs
      */
+    @Override
     protected Object writeReplace() throws ObjectStreamException
     {
         if (useCache)

--- a/src/main/java/org/datanucleus/store/types/wrappers/backed/Properties.java
+++ b/src/main/java/org/datanucleus/store/types/wrappers/backed/Properties.java
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- 
+
 
 Contributors:
     ...
@@ -20,6 +20,7 @@ package org.datanucleus.store.types.wrappers.backed;
 
 import java.io.ObjectStreamException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -38,14 +39,17 @@ import org.datanucleus.util.Localiser;
 import org.datanucleus.util.NucleusLogger;
 
 /**
- * A mutable second-class Properties object. Backed by a MapStore object.
- * The key and value types of this class is {@link java.lang.String}.
+ * A mutable second-class Properties object. Backed by a MapStore object. The key and value types of this
+ * class is {@link java.lang.String}.
  */
 public class Properties extends org.datanucleus.store.types.wrappers.Properties implements BackedSCO
 {
     protected transient MapStore backingStore;
+
     protected transient boolean allowNulls = false;
+
     protected transient boolean useCache = true;
+
     protected transient boolean isCacheLoaded = false;
 
     /**
@@ -63,29 +67,30 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
 
         if (!SCOUtils.mapHasSerialisedKeysAndValues(mmd) && mmd.getPersistenceModifier() == FieldPersistenceModifier.PERSISTENT)
         {
-            this.backingStore = (MapStore)((BackedSCOStoreManager)ownerOP.getStoreManager()).getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), 
-                mmd, java.util.Map.class);
+            this.backingStore = (MapStore) ((BackedSCOStoreManager) ownerOP.getStoreManager())
+                    .getBackingStoreForField(ownerOP.getExecutionContext().getClassLoaderResolver(), mmd, java.util.Map.class);
         }
 
         if (NucleusLogger.PERSISTENCE.isDebugEnabled())
         {
-            NucleusLogger.PERSISTENCE.debug(SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
+            NucleusLogger.PERSISTENCE.debug(
+                SCOUtils.getContainerInfoMessage(ownerOP, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd)));
         }
     }
 
+    @Override
     public void initialise(java.util.Properties newValue, Object oldValue)
     {
         if (newValue != null)
         {
             // Check for the case of serialised maps, and assign ObjectProviders to any PC keys/values without
-            if (SCOUtils.mapHasSerialisedKeysAndValues(ownerMmd) &&
-                (ownerMmd.getMap().keyIsPersistent() || ownerMmd.getMap().valueIsPersistent()))
+            if (SCOUtils.mapHasSerialisedKeysAndValues(ownerMmd) && (ownerMmd.getMap().keyIsPersistent() || ownerMmd.getMap().valueIsPersistent()))
             {
                 ExecutionContext ec = ownerOP.getExecutionContext();
                 Iterator iter = newValue.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -93,7 +98,8 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                         ObjectProvider objSM = ec.findObjectProvider(key);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -101,7 +107,8 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                         ObjectProvider objSM = ec.findObjectProvider(value);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -115,7 +122,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
             if (useCache)
             {
                 // Load up old values into delegate as starting point
-                java.util.Map oldMap = (java.util.Map)oldValue;
+                java.util.Map oldMap = (java.util.Map) oldValue;
                 if (oldMap != null)
                 {
                     delegate.putAll(oldMap);
@@ -131,7 +138,8 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                 {
                     if (SCOUtils.useQueuedUpdate(ownerOP))
                     {
-                        // If not yet flushed to store then no need to add to queue (since will be handled via insert)
+                        // If not yet flushed to store then no need to add to queue (since will be handled via
+                        // insert)
                         if (ownerOP.isFlushedToDatastore() || !ownerOP.getLifecycleState().isNew())
                         {
                             ownerOP.getExecutionContext().addOperationToQueue(new MapClearOperation(ownerOP, backingStore));
@@ -139,7 +147,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                             Iterator iter = newValue.entrySet().iterator();
                             while (iter.hasNext())
                             {
-                                java.util.Map.Entry entry = (java.util.Map.Entry)iter.next();
+                                java.util.Map.Entry entry = (java.util.Map.Entry) iter.next();
                                 ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                             }
                         }
@@ -147,7 +155,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                     else
                     {
                         backingStore.clear(ownerOP);
-                        backingStore.putAll(ownerOP, newValue);
+                        backingStore.putAll(ownerOP, newValue, Collections.emptyMap());
                     }
                 }
                 delegate.putAll(newValue);
@@ -161,6 +169,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * Method to initialise the SCO from an existing value.
      * @param m Object to set value using.
      */
+    @Override
     public void initialise(java.util.Properties m)
     {
         if (m != null)
@@ -172,7 +181,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -180,7 +189,8 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                         ObjectProvider objSM = ec.findObjectProvider(key);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -188,7 +198,8 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                         ObjectProvider objSM = ec.findObjectProvider(value);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -207,6 +218,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
     /**
      * Method to initialise the SCO for use.
      */
+    @Override
     public void initialise()
     {
         if (useCache && !SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd))
@@ -220,6 +232,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * Accessor for the unwrapped value that we are wrapping.
      * @return The unwrapped value
      */
+    @Override
     public java.util.Properties getValue()
     {
         loadFromStore();
@@ -227,9 +240,10 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
     }
 
     /**
-     * Method to effect the load of the data in the SCO.
-     * Used when the SCO supports lazy-loading to tell it to load all now.
+     * Method to effect the load of the data in the SCO. Used when the SCO supports lazy-loading to tell it to
+     * load all now.
      */
+    @Override
     public void load()
     {
         if (useCache)
@@ -239,10 +253,11 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
     }
 
     /**
-     * Method to return if the SCO has its contents loaded.
-     * If the SCO doesn't support lazy loading will just return true.
+     * Method to return if the SCO has its contents loaded. If the SCO doesn't support lazy loading will just
+     * return true.
      * @return Whether it is loaded
      */
+    @Override
     public boolean isLoaded()
     {
         return useCache ? isCacheLoaded : false;
@@ -257,8 +272,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             if (NucleusLogger.PERSISTENCE.isDebugEnabled())
             {
-                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", 
-                    ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
+                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
             }
             delegate.clear();
 
@@ -269,9 +283,11 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.datanucleus.store.types.backed.BackedSCO#getBackingStore()
      */
+    @Override
     public Store getBackingStore()
     {
         return backingStore;
@@ -284,6 +300,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedKey(Object key, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -299,6 +316,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedValue(Object value, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -310,6 +328,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
     /**
      * Method to unset the owner and field details.
      **/
+    @Override
     public void unsetOwner()
     {
         super.unsetOwner();
@@ -320,13 +339,16 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
     }
 
     // ------------------ Implementation of Hashtable methods ------------------
-    
+
     /**
      * Creates and returns a copy of this object.
-     * <P>Mutable second-class Objects are required to provide a public clone method in order to allow for copying persistable objects.
-     * In contrast to Object.clone(), this method must not throw a CloneNotSupportedException.
+     * <P>
+     * Mutable second-class Objects are required to provide a public clone method in order to allow for
+     * copying persistable objects. In contrast to Object.clone(), this method must not throw a
+     * CloneNotSupportedException.
      * @return The cloned object
      */
+    @Override
     public synchronized Object clone()
     {
         if (useCache)
@@ -336,12 +358,13 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
 
         return delegate.clone();
     }
-    
+
     /**
      * Method to return if the map contains this key
      * @param key The key
      * @return Whether it is contained
      **/
+    @Override
     public synchronized boolean containsKey(Object key)
     {
         if (useCache && isCacheLoaded)
@@ -353,15 +376,16 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return backingStore.containsKey(ownerOP, key);
         }
-        
+
         return delegate.containsKey(key);
     }
-    
+
     /**
      * Method to return if the map contains this value.
      * @param value The value
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsValue(Object value)
     {
         if (useCache && isCacheLoaded)
@@ -373,14 +397,15 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return backingStore.containsValue(ownerOP, value);
         }
-        
+
         return delegate.containsValue(value);
     }
-    
+
     /**
      * Accessor for the set of entries in the Map.
      * @return Set of entries
      **/
+    @Override
     public java.util.Set entrySet()
     {
         if (useCache)
@@ -391,22 +416,23 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return new Set(ownerOP, ownerMmd, false, backingStore.entrySetStore());
         }
-        
+
         return delegate.entrySet();
     }
-    
+
     /**
      * Method to check the equality of this map, and another.
      * @param o The map to compare against.
      * @return Whether they are equal.
      **/
+    @Override
     public synchronized boolean equals(Object o)
     {
         if (useCache)
         {
             loadFromStore();
         }
-        
+
         if (o == this)
         {
             return true;
@@ -415,8 +441,8 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return false;
         }
-        java.util.Map m = (java.util.Map)o;
-        
+        java.util.Map m = (java.util.Map) o;
+
         return entrySet().equals(m.entrySet());
     }
 
@@ -425,6 +451,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * @param key The key
      * @return The value.
      */
+    @Override
     public synchronized Object get(Object key)
     {
         if (useCache)
@@ -435,7 +462,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return backingStore.get(ownerOP, key);
         }
-        
+
         return delegate.get(key);
     }
 
@@ -444,6 +471,7 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * @param key The key
      * @return The value.
      */
+    @Override
     public synchronized String getProperty(String key)
     {
         if (useCache)
@@ -453,17 +481,18 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         else if (backingStore != null)
         {
             Object val = backingStore.get(ownerOP, key);
-            String strVal = (val instanceof String) ? (String)val : null;
+            String strVal = (val instanceof String) ? (String) val : null;
             return ((strVal == null) && (defaults != null)) ? defaults.getProperty(key) : strVal;
         }
 
         return delegate.getProperty(key);
     }
-    
+
     /**
      * Method to generate a hashcode for this Map.
      * @return The hashcode.
      **/
+    @Override
     public synchronized int hashCode()
     {
         if (useCache)
@@ -478,25 +507,27 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
             {
                 h += i.next().hashCode();
             }
-            
+
             return h;
         }
         return delegate.hashCode();
     }
-    
+
     /**
      * Method to return if the Map is empty.
      * @return Whether it is empty.
      **/
+    @Override
     public synchronized boolean isEmpty()
     {
         return size() == 0;
     }
-    
+
     /**
      * Accessor for the set of keys in the Map.
      * @return Set of keys.
      **/
+    @Override
     public java.util.Set keySet()
     {
         if (useCache)
@@ -507,14 +538,15 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return new Set(ownerOP, ownerMmd, false, backingStore.keySetStore());
         }
-        
+
         return delegate.keySet();
     }
-    
+
     /**
      * Method to return the size of the Map.
      * @return The size
      **/
+    @Override
     public synchronized int size()
     {
         if (useCache && isCacheLoaded)
@@ -526,14 +558,15 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return backingStore.entrySetStore().size(ownerOP);
         }
-        
+
         return delegate.size();
     }
-    
+
     /**
      * Accessor for the set of values in the Map.
      * @return Set of values.
      **/
+    @Override
     public Collection values()
     {
         if (useCache)
@@ -544,20 +577,21 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         {
             return new org.datanucleus.store.types.wrappers.backed.Collection(ownerOP, ownerMmd, true, backingStore.valueCollectionStore());
         }
-        
+
         return delegate.values();
     }
-    
+
     // -------------------------------- Mutator methods ------------------------
-    
+
     /**
      * Method to clear the Hashtable
      **/
+    @Override
     public synchronized void clear()
     {
         makeDirty();
         delegate.clear();
-        
+
         if (backingStore != null)
         {
             if (SCOUtils.useQueuedUpdate(ownerOP))
@@ -575,14 +609,15 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
             ownerOP.getExecutionContext().processNontransactionalUpdate();
         }
     }
-    
+
     /**
      * Method to add a value against a key to the Hashtable
      * @param key The key
      * @param value The value
      * @return The previous value for the specified key.
      **/
-    public synchronized Object put(Object key,Object value)
+    @Override
+    public synchronized Object put(Object key, Object value)
     {
         // Reject inappropriate elements
         if (!allowNulls)
@@ -633,11 +668,12 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
         }
         return oldValue;
     }
-    
+
     /**
      * Method to add the specified Map's values under their keys here.
      * @param m The map
      **/
+    @Override
     public synchronized void putAll(java.util.Map m)
     {
         makeDirty();
@@ -655,13 +691,13 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                 }
             }
             else
             {
-                backingStore.putAll(ownerOP, m);
+                backingStore.putAll(ownerOP, m, useCache ? Collections.unmodifiableMap(delegate) : null);
             }
         }
         delegate.putAll(m);
@@ -671,12 +707,13 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
             ownerOP.getExecutionContext().processNontransactionalUpdate();
         }
     }
-    
+
     /**
      * Method to remove the value for a key from the Hashtable
      * @param key The key to remove
      * @return The value that was removed from this key.
      **/
+    @Override
     public synchronized Object remove(Object key)
     {
         makeDirty();
@@ -719,24 +756,23 @@ public class Properties extends org.datanucleus.store.types.wrappers.Properties 
      * @param value The value
      * @return The previous value for the specified key.
      */
+    @Override
     public synchronized Object setProperty(String key, String value)
     {
         return put(key, value);
     }
 
     /**
-     * The writeReplace method is called when ObjectOutputStream is preparing
-     * to write the object to the stream. The ObjectOutputStream checks whether
-     * the class defines the writeReplace method. If the method is defined, the
-     * writeReplace method is called to allow the object to designate its
-     * replacement in the stream. The object returned should be either of the
-     * same type as the object passed in or an object that when read and 
-     * resolved will result in an object of a type that is compatible with all
-     * references to the object.
-     * 
+     * The writeReplace method is called when ObjectOutputStream is preparing to write the object to the
+     * stream. The ObjectOutputStream checks whether the class defines the writeReplace method. If the method
+     * is defined, the writeReplace method is called to allow the object to designate its replacement in the
+     * stream. The object returned should be either of the same type as the object passed in or an object that
+     * when read and resolved will result in an object of a type that is compatible with all references to the
+     * object.
      * @return the replaced object
      * @throws ObjectStreamException if an error occurs
      */
+    @Override
     protected Object writeReplace() throws ObjectStreamException
     {
         if (useCache)

--- a/src/main/java/org/datanucleus/store/types/wrappers/backed/SortedMap.java
+++ b/src/main/java/org/datanucleus/store/types/wrappers/backed/SortedMap.java
@@ -20,6 +20,7 @@ package org.datanucleus.store.types.wrappers.backed;
 
 import java.io.ObjectStreamException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -49,8 +50,11 @@ import org.datanucleus.util.NucleusLogger;
 public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.SortedMap<K, V> implements BackedSCO
 {
     protected transient MapStore<K, V> backingStore;
+
     protected transient boolean allowNulls = false;
+
     protected transient boolean useCache = true;
+
     protected transient boolean isCacheLoaded = false;
 
     /**
@@ -71,16 +75,17 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
 
         if (!SCOUtils.mapHasSerialisedKeysAndValues(mmd) && mmd.getPersistenceModifier() == FieldPersistenceModifier.PERSISTENT)
         {
-            this.backingStore = (MapStore)((BackedSCOStoreManager)ownerOP.getStoreManager()).getBackingStoreForField(clr, mmd, java.util.SortedMap.class);
+            this.backingStore = (MapStore) ((BackedSCOStoreManager) ownerOP.getStoreManager()).getBackingStoreForField(clr, mmd, java.util.SortedMap.class);
         }
-
 
         if (NucleusLogger.PERSISTENCE.isDebugEnabled())
         {
-            NucleusLogger.PERSISTENCE.debug(SCOUtils.getContainerInfoMessage(op, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(op, ownerMmd)));
+            NucleusLogger.PERSISTENCE
+                    .debug(SCOUtils.getContainerInfoMessage(op, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(op, ownerMmd)));
         }
     }
 
+    @Override
     public void initialise(java.util.SortedMap newValue, Object oldValue)
     {
         if (newValue != null)
@@ -92,7 +97,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                 Iterator iter = newValue.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -100,7 +105,8 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                         ObjectProvider objSM = ec.findObjectProvider(key);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -108,7 +114,8 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                         ObjectProvider objSM = ec.findObjectProvider(value);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -122,7 +129,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
             if (useCache)
             {
                 // Load up old values into delegate as starting point
-                java.util.Map oldMap = (java.util.Map)oldValue;
+                java.util.Map oldMap = (java.util.Map) oldValue;
                 if (oldMap != null)
                 {
                     delegate.putAll(oldMap);
@@ -138,7 +145,8 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                 {
                     if (SCOUtils.useQueuedUpdate(ownerOP))
                     {
-                        // If not yet flushed to store then no need to add to queue (since will be handled via insert)
+                        // If not yet flushed to store then no need to add to queue (since will be handled via
+                        // insert)
                         if (ownerOP.isFlushedToDatastore() || !ownerOP.getLifecycleState().isNew())
                         {
                             ownerOP.getExecutionContext().addOperationToQueue(new MapClearOperation(ownerOP, backingStore));
@@ -146,7 +154,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                             Iterator iter = newValue.entrySet().iterator();
                             while (iter.hasNext())
                             {
-                                java.util.Map.Entry entry = (java.util.Map.Entry)iter.next();
+                                java.util.Map.Entry entry = (java.util.Map.Entry) iter.next();
                                 ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                             }
                         }
@@ -154,7 +162,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                     else
                     {
                         backingStore.clear(ownerOP);
-                        backingStore.putAll(ownerOP, newValue);
+                        backingStore.putAll(ownerOP, newValue, Collections.emptyMap());
                     }
                 }
                 delegate.putAll(newValue);
@@ -168,6 +176,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Method to initialise the SCO from an existing value.
      * @param m Object to set value using.
      */
+    @Override
     public void initialise(java.util.SortedMap m)
     {
         if (m != null)
@@ -179,7 +188,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -187,7 +196,8 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                         ObjectProvider objSM = ec.findObjectProvider(key);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -195,7 +205,8 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                         ObjectProvider objSM = ec.findObjectProvider(value);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -214,6 +225,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     /**
      * Method to initialise the SCO for use.
      */
+    @Override
     public void initialise()
     {
         if (useCache && !SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd))
@@ -227,6 +239,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Accessor for the unwrapped value that we are wrapping.
      * @return The unwrapped value
      */
+    @Override
     public java.util.SortedMap getValue()
     {
         loadFromStore();
@@ -234,9 +247,10 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     }
 
     /**
-     * Method to effect the load of the data in the SCO.
-     * Used when the SCO supports lazy-loading to tell it to load all now.
+     * Method to effect the load of the data in the SCO. Used when the SCO supports lazy-loading to tell it to
+     * load all now.
      */
+    @Override
     public void load()
     {
         if (useCache)
@@ -246,10 +260,11 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     }
 
     /**
-     * Method to return if the SCO has its contents loaded.
-     * If the SCO doesn't support lazy loading will just return true.
+     * Method to return if the SCO has its contents loaded. If the SCO doesn't support lazy loading will just
+     * return true.
      * @return Whether it is loaded
      */
+    @Override
     public boolean isLoaded()
     {
         return useCache ? isCacheLoaded : false;
@@ -264,8 +279,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
         {
             if (NucleusLogger.PERSISTENCE.isDebugEnabled())
             {
-                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006",
-                    ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
+                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
             }
             delegate.clear();
 
@@ -276,9 +290,11 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.datanucleus.store.types.backed.BackedSCO#getBackingStore()
      */
+    @Override
     public Store getBackingStore()
     {
         return backingStore;
@@ -291,6 +307,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedKey(K key, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -306,6 +323,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedValue(V value, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -317,6 +335,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     /**
      * Method to unset the owner and field details.
      */
+    @Override
     public void unsetOwner()
     {
         super.unsetOwner();
@@ -327,13 +346,16 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     }
 
     // ------------------ Implementation of SortedMap methods --------------------
- 
+
     /**
      * Creates and returns a copy of this object.
-     * <P>Mutable second-class Objects are required to provide a public clone method in order to allow for copying persistable objects.
-     * In contrast to Object.clone(), this method must not throw a CloneNotSupportedException.
+     * <P>
+     * Mutable second-class Objects are required to provide a public clone method in order to allow for
+     * copying persistable objects. In contrast to Object.clone(), this method must not throw a
+     * CloneNotSupportedException.
      * @return The cloned object
      */
+    @Override
     public Object clone()
     {
         if (useCache)
@@ -341,13 +363,14 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
             loadFromStore();
         }
 
-        return ((java.util.TreeMap)delegate).clone();
+        return ((java.util.TreeMap) delegate).clone();
     }
 
     /**
      * Accessor for the comparator.
      * @return The comparator
      */
+    @Override
     public Comparator comparator()
     {
         return delegate.comparator();
@@ -358,6 +381,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param key The key
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsKey(Object key)
     {
         if (useCache && isCacheLoaded)
@@ -378,6 +402,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param value The value
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsValue(Object value)
     {
         if (useCache && isCacheLoaded)
@@ -397,6 +422,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Accessor for the set of entries in the Map.
      * @return Set of entries
      **/
+    @Override
     public java.util.Set entrySet()
     {
         if (useCache)
@@ -416,6 +442,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param o The map to compare against.
      * @return Whether they are equal.
      **/
+    @Override
     public boolean equals(Object o)
     {
         if (useCache)
@@ -431,7 +458,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
         {
             return false;
         }
-        java.util.Map m = (java.util.Map)o;
+        java.util.Map m = (java.util.Map) o;
 
         return entrySet().equals(m.entrySet());
     }
@@ -440,6 +467,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Accessor for the first key in the sorted map.
      * @return The first key
      **/
+    @Override
     public K firstKey()
     {
         if (useCache && isCacheLoaded)
@@ -488,6 +516,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Accessor for the last key in the sorted map.
      * @return The last key
      **/
+    @Override
     public K lastKey()
     {
         if (useCache && isCacheLoaded)
@@ -520,6 +549,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param toKey the key to return up to.
      * @return The map meeting the input
      */
+    @Override
     public java.util.SortedMap headMap(K toKey)
     {
         if (useCache && isCacheLoaded)
@@ -546,6 +576,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param toKey The end key
      * @return The map meeting the input
      */
+    @Override
     public java.util.SortedMap subMap(K fromKey, K toKey)
     {
         if (useCache && isCacheLoaded)
@@ -571,6 +602,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param fromKey The start key
      * @return The map meeting the input
      */
+    @Override
     public java.util.SortedMap tailMap(K fromKey)
     {
         if (useCache && isCacheLoaded)
@@ -596,6 +628,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param key The key
      * @return The value.
      **/
+    @Override
     public V get(Object key)
     {
         if (useCache)
@@ -614,6 +647,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Method to generate a hashcode for this Map.
      * @return The hashcode.
      **/
+    @Override
     public int hashCode()
     {
         if (useCache)
@@ -638,6 +672,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Method to return if the Map is empty.
      * @return Whether it is empty.
      **/
+    @Override
     public boolean isEmpty()
     {
         return size() == 0;
@@ -647,6 +682,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Accessor for the set of keys in the Map.
      * @return Set of keys.
      **/
+    @Override
     public java.util.Set keySet()
     {
         if (useCache)
@@ -665,6 +701,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Method to return the size of the Map.
      * @return The size
      **/
+    @Override
     public int size()
     {
         if (useCache && isCacheLoaded)
@@ -684,6 +721,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Accessor for the set of values in the Map.
      * @return Set of values.
      **/
+    @Override
     public Collection values()
     {
         if (useCache)
@@ -699,10 +737,11 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     }
 
     // --------------------------- Mutator methods -----------------------------
- 
+
     /**
      * Method to clear the SortedMap.
      **/
+    @Override
     public void clear()
     {
         makeDirty();
@@ -725,13 +764,14 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
             ownerOP.getExecutionContext().processNontransactionalUpdate();
         }
     }
- 
+
     /**
      * Method to add a value against a key to the SortedMap.
      * @param key The key
      * @param value The value
      * @return The previous value for the specified key.
      **/
+    @Override
     public V put(K key, V value)
     {
         // Reject inappropriate values
@@ -788,6 +828,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * Method to add the specified Map's values under their keys here.
      * @param m The map
      **/
+    @Override
     public void putAll(java.util.Map m)
     {
         makeDirty();
@@ -805,13 +846,13 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                 }
             }
             else
             {
-                backingStore.putAll(ownerOP, m);
+                backingStore.putAll(ownerOP, m, useCache ? Collections.unmodifiableMap(delegate) : null);
             }
         }
         delegate.putAll(m);
@@ -827,6 +868,7 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
      * @param key The key to remove
      * @return The value that was removed from this key.
      **/
+    @Override
     public V remove(Object key)
     {
         makeDirty();
@@ -864,18 +906,16 @@ public class SortedMap<K, V> extends org.datanucleus.store.types.wrappers.Sorted
     }
 
     /**
-     * The writeReplace method is called when ObjectOutputStream is preparing
-     * to write the object to the stream. The ObjectOutputStream checks whether
-     * the class defines the writeReplace method. If the method is defined, the
-     * writeReplace method is called to allow the object to designate its
-     * replacement in the stream. The object returned should be either of the
-     * same type as the object passed in or an object that when read and
-     * resolved will result in an object of a type that is compatible with all
-     * references to the object.
-     * 
+     * The writeReplace method is called when ObjectOutputStream is preparing to write the object to the
+     * stream. The ObjectOutputStream checks whether the class defines the writeReplace method. If the method
+     * is defined, the writeReplace method is called to allow the object to designate its replacement in the
+     * stream. The object returned should be either of the same type as the object passed in or an object that
+     * when read and resolved will result in an object of a type that is compatible with all references to the
+     * object.
      * @return the replaced object
      * @throws ObjectStreamException if an error occurs
      */
+    @Override
     protected Object writeReplace() throws ObjectStreamException
     {
         if (useCache)

--- a/src/main/java/org/datanucleus/store/types/wrappers/backed/TreeMap.java
+++ b/src/main/java/org/datanucleus/store/types/wrappers/backed/TreeMap.java
@@ -20,6 +20,7 @@ package org.datanucleus.store.types.wrappers.backed;
 
 import java.io.ObjectStreamException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -50,8 +51,11 @@ import org.datanucleus.util.NucleusLogger;
 public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<K, V> implements BackedSCO
 {
     protected transient MapStore<K, V> backingStore;
+
     protected transient boolean allowNulls = false;
+
     protected transient boolean useCache = true;
+
     protected transient boolean isCacheLoaded = false;
 
     /**
@@ -72,15 +76,17 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
 
         if (!SCOUtils.mapHasSerialisedKeysAndValues(mmd) && mmd.getPersistenceModifier() == FieldPersistenceModifier.PERSISTENT)
         {
-            this.backingStore = (MapStore)((BackedSCOStoreManager)ownerOP.getStoreManager()).getBackingStoreForField(clr, mmd, java.util.TreeMap.class);
+            this.backingStore = (MapStore) ((BackedSCOStoreManager) ownerOP.getStoreManager()).getBackingStoreForField(clr, mmd, java.util.TreeMap.class);
         }
 
         if (NucleusLogger.PERSISTENCE.isDebugEnabled())
         {
-            NucleusLogger.PERSISTENCE.debug(SCOUtils.getContainerInfoMessage(op, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(op, ownerMmd)));
+            NucleusLogger.PERSISTENCE
+                    .debug(SCOUtils.getContainerInfoMessage(op, ownerMmd.getName(), this, useCache, allowNulls, SCOUtils.useCachedLazyLoading(op, ownerMmd)));
         }
     }
 
+    @Override
     public void initialise(java.util.TreeMap newValue, Object oldValue)
     {
         if (newValue != null)
@@ -92,7 +98,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                 Iterator iter = newValue.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -100,7 +106,8 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                         ObjectProvider objSM = ec.findObjectProvider(key);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -108,7 +115,8 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                         ObjectProvider objSM = ec.findObjectProvider(value);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -122,7 +130,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
             if (useCache)
             {
                 // Load up old values into delegate as starting point
-                java.util.Map oldMap = (java.util.Map)oldValue;
+                java.util.Map oldMap = (java.util.Map) oldValue;
                 if (oldMap != null)
                 {
                     delegate.putAll(oldMap);
@@ -138,7 +146,8 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                 {
                     if (SCOUtils.useQueuedUpdate(ownerOP))
                     {
-                        // If not yet flushed to store then no need to add to queue (since will be handled via insert)
+                        // If not yet flushed to store then no need to add to queue (since will be handled via
+                        // insert)
                         if (ownerOP.isFlushedToDatastore() || !ownerOP.getLifecycleState().isNew())
                         {
                             ownerOP.getExecutionContext().addOperationToQueue(new MapClearOperation(ownerOP, backingStore));
@@ -146,7 +155,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                             Iterator iter = newValue.entrySet().iterator();
                             while (iter.hasNext())
                             {
-                                java.util.Map.Entry entry = (java.util.Map.Entry)iter.next();
+                                java.util.Map.Entry entry = (java.util.Map.Entry) iter.next();
                                 ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                             }
                         }
@@ -154,7 +163,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                     else
                     {
                         backingStore.clear(ownerOP);
-                        backingStore.putAll(ownerOP, newValue);
+                        backingStore.putAll(ownerOP, newValue, Collections.emptyMap());
                     }
                 }
                 delegate.putAll(newValue);
@@ -168,6 +177,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Method to initialise the SCO from an existing value.
      * @param m Object to set value using.
      */
+    @Override
     public void initialise(java.util.TreeMap m)
     {
         if (m != null)
@@ -179,7 +189,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     Object key = entry.getKey();
                     Object value = entry.getValue();
                     if (ownerMmd.getMap().keyIsPersistent())
@@ -187,7 +197,8 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                         ObjectProvider objSM = ec.findObjectProvider(key);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, key, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                     if (ownerMmd.getMap().valueIsPersistent())
@@ -195,7 +206,8 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                         ObjectProvider objSM = ec.findObjectProvider(value);
                         if (objSM == null)
                         {
-                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP, ownerMmd.getAbsoluteFieldNumber());
+                            objSM = ec.getNucleusContext().getObjectProviderFactory().newForEmbedded(ec, value, false, ownerOP,
+                                ownerMmd.getAbsoluteFieldNumber());
                         }
                     }
                 }
@@ -214,6 +226,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     /**
      * Method to initialise the SCO for use.
      */
+    @Override
     public void initialise()
     {
         if (useCache && !SCOUtils.useCachedLazyLoading(ownerOP, ownerMmd))
@@ -227,6 +240,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the unwrapped value that we are wrapping.
      * @return The unwrapped value
      */
+    @Override
     public java.util.TreeMap getValue()
     {
         loadFromStore();
@@ -234,9 +248,10 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     }
 
     /**
-     * Method to effect the load of the data in the SCO.
-     * Used when the SCO supports lazy-loading to tell it to load all now.
+     * Method to effect the load of the data in the SCO. Used when the SCO supports lazy-loading to tell it to
+     * load all now.
      */
+    @Override
     public void load()
     {
         if (useCache)
@@ -246,10 +261,11 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     }
 
     /**
-     * Method to return if the SCO has its contents loaded.
-     * If the SCO doesn't support lazy loading will just return true.
+     * Method to return if the SCO has its contents loaded. If the SCO doesn't support lazy loading will just
+     * return true.
      * @return Whether it is loaded
      */
+    @Override
     public boolean isLoaded()
     {
         return useCache ? isCacheLoaded : false;
@@ -264,8 +280,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
         {
             if (NucleusLogger.PERSISTENCE.isDebugEnabled())
             {
-                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", 
-                    ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
+                NucleusLogger.PERSISTENCE.debug(Localiser.msg("023006", ownerOP.getObjectAsPrintable(), ownerMmd.getName()));
             }
             delegate.clear();
 
@@ -276,9 +291,11 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
         }
     }
 
-    /* (non-Javadoc)
+    /*
+     * (non-Javadoc)
      * @see org.datanucleus.store.types.backed.BackedSCO#getBackingStore()
      */
+    @Override
     public Store getBackingStore()
     {
         return backingStore;
@@ -291,6 +308,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedKey(K key, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -306,6 +324,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param newValue New value for this field
      * @param makeDirty Whether to make the SCO field dirty.
      */
+    @Override
     public void updateEmbeddedValue(V value, int fieldNumber, Object newValue, boolean makeDirty)
     {
         if (backingStore != null)
@@ -317,6 +336,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     /**
      * Method to unset the owner and field details.
      */
+    @Override
     public void unsetOwner()
     {
         super.unsetOwner();
@@ -327,13 +347,16 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     }
 
     // ------------------ Implementation of TreeMap methods --------------------
- 
+
     /**
      * Creates and returns a copy of this object.
-     * <P>Mutable second-class Objects are required to provide a public clone method in order to allow for copying persistable objects.
-     * In contrast to Object.clone(), this method must not throw a CloneNotSupportedException.
+     * <P>
+     * Mutable second-class Objects are required to provide a public clone method in order to allow for
+     * copying persistable objects. In contrast to Object.clone(), this method must not throw a
+     * CloneNotSupportedException.
      * @return The cloned object
      */
+    @Override
     public Object clone()
     {
         if (useCache)
@@ -348,6 +371,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the comparator.
      * @return The comparator
      */
+    @Override
     public Comparator comparator()
     {
         return delegate.comparator();
@@ -358,6 +382,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param key The key
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsKey(Object key)
     {
         if (useCache && isCacheLoaded)
@@ -378,6 +403,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param value The value
      * @return Whether it is contained
      **/
+    @Override
     public boolean containsValue(Object value)
     {
         if (useCache && isCacheLoaded)
@@ -397,6 +423,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the set of entries in the Map.
      * @return Set of entries
      **/
+    @Override
     public java.util.Set entrySet()
     {
         if (useCache)
@@ -416,6 +443,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param o The map to compare against.
      * @return Whether they are equal.
      **/
+    @Override
     public boolean equals(Object o)
     {
         if (useCache)
@@ -431,7 +459,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
         {
             return false;
         }
-        java.util.Map m = (java.util.Map)o;
+        java.util.Map m = (java.util.Map) o;
 
         return entrySet().equals(m.entrySet());
     }
@@ -440,6 +468,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the first key in the sorted map.
      * @return The first key
      **/
+    @Override
     public K firstKey()
     {
         if (useCache && isCacheLoaded)
@@ -488,6 +517,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the last key in the sorted map.
      * @return The last key
      **/
+    @Override
     public K lastKey()
     {
         if (useCache && isCacheLoaded)
@@ -520,6 +550,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param toKey the key to return up to.
      * @return The map meeting the input
      */
+    @Override
     public SortedMap headMap(K toKey)
     {
         if (useCache && isCacheLoaded)
@@ -546,6 +577,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param toKey The end key
      * @return The map meeting the input
      */
+    @Override
     public SortedMap subMap(K fromKey, K toKey)
     {
         if (useCache && isCacheLoaded)
@@ -571,6 +603,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param fromKey The start key
      * @return The map meeting the input
      */
+    @Override
     public SortedMap tailMap(K fromKey)
     {
         if (useCache && isCacheLoaded)
@@ -596,6 +629,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param key The key
      * @return The value.
      **/
+    @Override
     public V get(Object key)
     {
         if (useCache)
@@ -614,6 +648,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Method to generate a hashcode for this Map.
      * @return The hashcode.
      **/
+    @Override
     public int hashCode()
     {
         if (useCache)
@@ -638,6 +673,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Method to return if the Map is empty.
      * @return Whether it is empty.
      **/
+    @Override
     public boolean isEmpty()
     {
         return size() == 0;
@@ -647,6 +683,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the set of keys in the Map.
      * @return Set of keys.
      **/
+    @Override
     public java.util.Set keySet()
     {
         if (useCache)
@@ -665,6 +702,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Method to return the size of the Map.
      * @return The size
      **/
+    @Override
     public int size()
     {
         if (useCache && isCacheLoaded)
@@ -684,6 +722,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Accessor for the set of values in the Map.
      * @return Set of values.
      **/
+    @Override
     public Collection values()
     {
         if (useCache)
@@ -699,10 +738,11 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     }
 
     // --------------------------- Mutator methods -----------------------------
- 
+
     /**
      * Method to clear the TreeMap.
      **/
+    @Override
     public void clear()
     {
         makeDirty();
@@ -725,13 +765,14 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
             ownerOP.getExecutionContext().processNontransactionalUpdate();
         }
     }
- 
+
     /**
      * Method to add a value against a key to the TreeMap.
      * @param key The key
      * @param value The value
      * @return The previous value for the specified key.
      */
+    @Override
     public V put(K key, V value)
     {
         // Reject inappropriate values
@@ -788,6 +829,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * Method to add the specified Map's values under their keys here.
      * @param m The map
      **/
+    @Override
     public void putAll(java.util.Map m)
     {
         makeDirty();
@@ -805,13 +847,13 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
                 Iterator iter = m.entrySet().iterator();
                 while (iter.hasNext())
                 {
-                    Map.Entry entry = (Map.Entry)iter.next();
+                    Map.Entry entry = (Map.Entry) iter.next();
                     ownerOP.getExecutionContext().addOperationToQueue(new MapPutOperation(ownerOP, backingStore, entry.getKey(), entry.getValue()));
                 }
             }
             else
             {
-                backingStore.putAll(ownerOP, m);
+                backingStore.putAll(ownerOP, m, useCache ? Collections.unmodifiableMap(delegate) : null);
             }
         }
         delegate.putAll(m);
@@ -827,6 +869,7 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
      * @param key The key to remove
      * @return The value that was removed from this key.
      **/
+    @Override
     public V remove(Object key)
     {
         makeDirty();
@@ -864,18 +907,16 @@ public class TreeMap<K, V> extends org.datanucleus.store.types.wrappers.TreeMap<
     }
 
     /**
-     * The writeReplace method is called when ObjectOutputStream is preparing
-     * to write the object to the stream. The ObjectOutputStream checks whether
-     * the class defines the writeReplace method. If the method is defined, the
-     * writeReplace method is called to allow the object to designate its
-     * replacement in the stream. The object returned should be either of the
-     * same type as the object passed in or an object that when read and
-     * resolved will result in an object of a type that is compatible with all
-     * references to the object.
-     * 
+     * The writeReplace method is called when ObjectOutputStream is preparing to write the object to the
+     * stream. The ObjectOutputStream checks whether the class defines the writeReplace method. If the method
+     * is defined, the writeReplace method is called to allow the object to designate its replacement in the
+     * stream. The object returned should be either of the same type as the object passed in or an object that
+     * when read and resolved will result in an object of a type that is compatible with all references to the
+     * object.
      * @return the replaced object
      * @throws ObjectStreamException if an error occurs
      */
+    @Override
     protected Object writeReplace() throws ObjectStreamException
     {
         if (useCache)


### PR DESCRIPTION
The backend maps to provide hints for putAll operations to MapStore.
The MapStore engine COULD shortcut the decision between INSERT(add) vs UPDATE(overwrite) by using the hint.
Result should avoiding round-trip latency to ask the underlying storage.

The delegate hints is only provided when
 - during initialization, which the map must be empty
 - useCache that it was loadFromStore (and keep sync)

This is optional that the MapStore implementation MAY ignore the hint, for locking or safety reasons.

For example, datanucleus-rdbms so a SELECT before INSERT/UPDATE.
JoinMapStore may use the hint to avoid SELECT queries.

Another approach is to use MERGE/UPSERT SQL statements on RDMBS who support it.
However UPSERT is not generic and still unsupported by many RDBMS.

------
I did sormatting the code in Eclipse with https://www.datanucleus.org/documentation/code-conventions-eclipse.xml and minor Java 8 syntax for files I touched. 



If I can get this merged,  I can go back to datanucleus-rdbms and continue rebase my previous patch to the master branch with a much smaller size of patch