### PR TITLE
Fix IS EMPTY clause for JPQL queries

### DIFF
--- a/src/main/java/org/datanucleus/query/compiler/JPQLParser.java
+++ b/src/main/java/org/datanucleus/query/compiler/JPQLParser.java
@@ -773,7 +773,7 @@ public class JPQLParser extends AbstractParser
                     Node sizeNode = new Node(NodeType.INVOKE, "size");
                     inputNode.insertChildNode(sizeNode);
                     Node isEmptyNode = new Node(NodeType.OPERATOR, not ? "!=" : "==");
-                    isEmptyNode.appendChildNode(inputNode);
+                    isEmptyNode.appendChildNode(inputRootNode);
                     Node zeroNode = new Node(NodeType.LITERAL, 0);
                     isEmptyNode.appendChildNode(zeroNode);
                     stack.push(isEmptyNode);


### PR DESCRIPTION
This change addresses an error in the JPQLParser class, where the new
node that is created to check that the size of a collection is zero is
attaching the wrong node as a child, resulting in the loss of the "path"
to the collection in the result of the query compilation