### PR TITLE
5.2: Use Log4j (v2) API as (still optional) dependency, and Core only with scope test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,15 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
+            <artifactId>log4j-api</artifactId>
             <version>2.13.2</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.13.2</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- For Java Management/MX4J -->


### PR DESCRIPTION
Use Log4j (v2) API as (still optional) dependency, and Core only with scope test.

@andyjefferson would you consider merging this? Please don't hesitate to ask if the Why of What here is not clear - I'm happy to elaborate, if needed.