### PR TITLE
Fix warning log line in ColumnMetaData

### DIFF
--- a/src/main/java/org/datanucleus/metadata/ColumnMetaData.java
+++ b/src/main/java/org/datanucleus/metadata/ColumnMetaData.java
@@ -184,7 +184,7 @@ public class ColumnMetaData extends MetaData
             }
             catch (IllegalArgumentException iae)
             {
-                NucleusLogger.METADATA.warn("Metadata has jdbc-type of " + jdbcType + " yet this is not valid. Ignored");
+                NucleusLogger.METADATA.warn("Metadata has jdbc-type of '" + jdbcTypeName + "' yet this is not valid. Ignored");
             }
         }
         return this;


### PR DESCRIPTION
The log line always read `Metadata has jdbc-type of null yet this is not valid. Ignored`