### PR TITLE
Replace hard-coded property String with PropertyNames constants

### DIFF
--- a/src/main/java/org/datanucleus/FetchPlan.java
+++ b/src/main/java/org/datanucleus/FetchPlan.java
@@ -115,7 +115,7 @@ public class FetchPlan implements Serializable
         groupNames.add(FetchPlan.DEFAULT);
 
         // Extension property to define the default detachmentOptions
-        String flds = ec.getNucleusContext().getConfiguration().getStringProperty("datanucleus.detachmentFields");
+        String flds = ec.getNucleusContext().getConfiguration().getStringProperty(PropertyNames.PROPERTY_DETACH_DETACHMENT_FIELDS);
         if (flds != null)
         {
             flds = flds.toLowerCase();


### PR DESCRIPTION
Every PropertyNames constant is converted to `xxx.toLowerCase()`, however, FetchPlan is using a hard-coded String without `.toLowerCase()`. This caused the property to always resolve to null

There is no reason for defining a hard-coded String in FetchPlan. We should always use the constant in PropertyNames