### PR TITLE
Replace hardcode string with PropertyNames constant

### DIFF
--- a/src/main/java/org/datanucleus/management/ManagementManager.java
+++ b/src/main/java/org/datanucleus/management/ManagementManager.java
@@ -63,7 +63,7 @@ public class ManagementManager
     {
         this.nucleusContext = ctxt;
 
-        this.domainName = ctxt.getConfiguration().getStringProperty("datanucleus.PersistenceUnitName");
+        this.domainName = ctxt.getConfiguration().getStringProperty(PropertyNames.PROPERTY_PERSISTENCE_UNIT_NAME);
         if (this.domainName == null)
         {
             this.domainName = "datanucleus";


### PR DESCRIPTION
Hard code property name String is used in `ManagementManager`, this should be replaced with constant defined in `PropertyNames`