### PR TITLE
Added new L2 Cache update mode: datastore-read-only. With this mode L2 cache is only updated on datastre-read and NOT at commit. A custom commit listener can be made to control L2 cache population during commit if required.

### DIFF
--- a/src/main/java/org/datanucleus/ExecutionContextImpl.java
+++ b/src/main/java/org/datanucleus/ExecutionContextImpl.java
@@ -4165,6 +4165,12 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
             return;
         }
 
+        String updateMode = getStringProperty(PropertyNames.PROPERTY_CACHE_L2_UPDATE_MODE);
+        if (updateMode != null && updateMode.equalsIgnoreCase("datastore-read-only"))
+        {
+            return;
+        }
+
         // Process all modified objects adding/updating/removing from L2 cache as appropriate
         Set<DNStateManager> smsToCache = null;
         Set<Object> idsToRemove = null;
@@ -4731,7 +4737,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
      * Performs the "put" in batches
      * @param sms StateManagers whose objects are to be cached
      */
-    protected void putObjectsIntoLevel2Cache(Set<DNStateManager> sms)
+    public void putObjectsIntoLevel2Cache(Set<DNStateManager> sms)
     {
         int batchSize = nucCtx.getConfiguration().getIntProperty(PropertyNames.PROPERTY_CACHE_L2_BATCHSIZE);
         Level2Cache l2Cache = nucCtx.getLevel2Cache();

--- a/src/main/java/org/datanucleus/properties/CorePropertyValidator.java
+++ b/src/main/java/org/datanucleus/properties/CorePropertyValidator.java
@@ -316,6 +316,7 @@ public class CorePropertyValidator implements PropertyValidator
             {
                 String strVal = ((String)value).toLowerCase();
                 if (strVal.equals("commit-and-datastore-read") ||
+                    strVal.equals("datastore-read-only") ||
                     strVal.equals("commit-only"))
                 {
                     return true;


### PR DESCRIPTION
Added new L2 Cache update mode: datastore-read-only. With this mode L2 cache is only updated on datastre-read and NOT at commit. A custom commit listener can be made to control L2 cache population during commit if required.