### PR TITLE
Improvements to ExecutionContext.findObject and Level 1 cache handling.

### DIFF
--- a/src/main/java/org/datanucleus/cache/SupportsConcurrentModificationsIteration.java
+++ b/src/main/java/org/datanucleus/cache/SupportsConcurrentModificationsIteration.java
@@ -1,0 +1,24 @@
+/**********************************************************************
+ Copyright (c) 2006 Andy Jefferson and others. All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **********************************************************************/
+package org.datanucleus.cache;
+
+/**
+ * Marker interface for collections where it's possible to make modifications while iterating.
+ * When used for Level 1 cache implementations there is a considerable performance benefit
+ * when closing an execution context with many objects in Level 1 cache.
+ */
+public interface SupportsConcurrentModificationsIteration
+{
+}

--- a/src/main/java/org/datanucleus/cache/TieredLevel1Cache.java
+++ b/src/main/java/org/datanucleus/cache/TieredLevel1Cache.java
@@ -1,0 +1,31 @@
+/**********************************************************************
+ Copyright (c) 2006 Andy Jefferson and others. All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **********************************************************************/
+package org.datanucleus.cache;
+
+import org.datanucleus.state.DNStateManager;
+
+/**
+ * A marker interface for Level1Cache for optimizing commit.
+ * During commit we are not interested in hollow PC objects in Level1
+ * cache - Level1 caches implementing this interface could optimize
+ * the filtering of finding non-hollow PC objects.
+ */
+public interface TieredLevel1Cache extends Level1Cache {
+    /**
+     * Return non-hollow state managers that could be considered as dirty during commit phase.
+     * @return non-hollow state managers to consider during commit phase
+     */
+    Iterable<? extends DNStateManager> hotValues();
+}

--- a/src/main/java/org/datanucleus/state/StateManagerImpl.java
+++ b/src/main/java/org/datanucleus/state/StateManagerImpl.java
@@ -1599,7 +1599,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
 
         // Add on version field if not currently set and using version field (surrogate will be added automatically by the query if required)
         int[] fieldNumbersToFetch = fieldNumbers;
-        if (cmd.isVersioned())
+        if (isVersioned())
         {
             VersionMetaData vermd = cmd.getVersionMetaDataForClass();
             if (vermd != null && vermd.getMemberName() != null)
@@ -2355,7 +2355,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
     {
         if (pc == myPC)
         {
-            if (transactionalVersion == null && cmd.isVersioned())
+            if (transactionalVersion == null && isVersioned())
             {
                 // If the object is versioned and no version is loaded (e.g obtained via findObject without loading fields) and in a state where we need it then pull in the version
                 VersionMetaData vermd = cmd.getVersionMetaDataForClass();
@@ -2387,7 +2387,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
      */
     public boolean isVersionLoaded()
     {
-        if (cmd.isVersioned())
+        if (isVersioned())
         {
             return transactionalVersion != null;
         }
@@ -2614,7 +2614,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2661,7 +2661,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2708,7 +2708,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2755,7 +2755,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2802,7 +2802,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2849,7 +2849,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2896,7 +2896,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2943,7 +2943,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -2990,7 +2990,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -3048,7 +3048,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
         }
         else if (myLC != null)
         {
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 // Not got version but should have
                 loadUnloadedFieldsInFetchPlanAndVersion();
@@ -3970,7 +3970,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
      */
     protected void loadUnloadedFieldsInFetchPlanAndVersion()
     {
-        if (!cmd.isVersioned())
+        if (!isVersioned())
         {
             loadUnloadedFieldsInFetchPlan();
         }
@@ -5573,7 +5573,7 @@ public class StateManagerImpl implements DNStateManager<Persistable>
             }
 
             boolean versionNeedsLoading = false;
-            if (cmd.isVersioned() && transactionalVersion == null)
+            if (isVersioned() && transactionalVersion == null)
             {
                 versionNeedsLoading = true;
             }
@@ -6239,5 +6239,10 @@ public class StateManagerImpl implements DNStateManager<Persistable>
             // Create the id for the new PC
             myID = myEC.getNucleusContext().getIdentityManager().getApplicationId(myPC, cmd);
         }
+    }
+
+    public boolean isVersioned()
+    {
+        return cmd.isVersioned();
     }
 }

--- a/src/main/java/org/datanucleus/store/ValidatingStorePersistenceHandler.java
+++ b/src/main/java/org/datanucleus/store/ValidatingStorePersistenceHandler.java
@@ -1,0 +1,39 @@
+/**********************************************************************
+ Copyright (c) 2009 Erik Bengtson and others. All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **********************************************************************/
+package org.datanucleus.store;
+
+import org.datanucleus.state.DNStateManager;
+
+/**
+ * Marker interface for StorePersistenceHandler implementations.
+ * Implementing this interface enabled the persistence handler
+ * to decide what to do if EC.findObject is requested to validate
+ * the existence of a found object.
+ * If the object was loaded in findObject from the persistence handler
+ * then it might not be necessary to check for its existence again in DB
+ * by calling sm.validate().
+ * We leave this decision to the persistence handler if it supports this optimization.
+ */
+public interface ValidatingStorePersistenceHandler
+{
+    /**
+     * Validates whether the supplied state manager instance exists in the datastore.
+     * If the instance does not exist in the datastore, this method will fail raising a NucleusObjectNotFoundException.
+     *
+     * @param sm the state manager instance to check
+     * @param readFromPersistenceHandler whether object was read from persistence handler in datastore.
+     */
+    void validate(DNStateManager sm, boolean readFromPersistenceHandler);
+}


### PR DESCRIPTION
Improved ExecutionContext.findObject to not return duplicate PC instances of already existing PC in Level 1 cache. Also improved ExecutionContext.findObject to not call PersistenceHandler.findObject if FieldValues is supplied with all the data. And enabled PersistenceHandler to avoid doing extra DB validate check if already found object from DB. And added custom Level 1 cache performance optimization.