### PR TITLE
Fix FlushMode not initialized from properties during ExecutionContext.initialise()

### DIFF
--- a/src/main/java/org/datanucleus/ExecutionContextImpl.java
+++ b/src/main/java/org/datanucleus/ExecutionContextImpl.java
@@ -329,6 +329,15 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
         }
         properties.getFrequentProperties().setDefaults(conf.getFrequentProperties());
 
+        // Initialise flushMode from copied properties since properties.setProperty() above
+        // only stores the value without triggering the field assignment in setProperty()
+        String flushModeProp = properties.getProperty(PropertyNames.PROPERTY_FLUSH_MODE) != null ?
+            properties.getProperty(PropertyNames.PROPERTY_FLUSH_MODE).toString() : null;
+        if (flushModeProp != null)
+        {
+            flushMode = FlushMode.getFlushModeForString(flushModeProp);
+        }
+
         // Set up FetchPlan
         fetchPlan = new FetchPlan(this, clr).setMaxFetchDepth(properties.getIntProperty(PropertyNames.PROPERTY_MAX_FETCH_DEPTH));
 

--- a/src/test/java/org/datanucleus/ExecutionContextFlushModeTest.java
+++ b/src/test/java/org/datanucleus/ExecutionContextFlushModeTest.java
@@ -1,0 +1,70 @@
+/**********************************************************************
+Copyright (c) 2026 Contributors. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contributors:
+    ...
+ **********************************************************************/
+package org.datanucleus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.datanucleus.flush.FlushMode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for FlushMode initialization during ExecutionContext construction.
+ */
+public class ExecutionContextFlushModeTest
+{
+    @Test
+    public void testFlushModeInitializedFromProperties()
+    {
+        Map<String, Object> props = new HashMap<>();
+        props.put(PropertyNames.PROPERTY_FLUSH_MODE, "AUTO");
+
+        PersistenceNucleusContextImpl ctx = new PersistenceNucleusContextImpl(null, props)
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public synchronized void initialise()
+            {
+            }
+        };
+
+        ExecutionContextImpl ec = new ExecutionContextImpl(ctx, null, new HashMap<String, Object>());
+        Assert.assertEquals(FlushMode.AUTO, ec.getFlushMode());
+    }
+
+    @Test
+    public void testFlushModeDefaultIsNull()
+    {
+        Map<String, Object> props = new HashMap<>();
+
+        PersistenceNucleusContextImpl ctx = new PersistenceNucleusContextImpl(null, props)
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public synchronized void initialise()
+            {
+            }
+        };
+
+        ExecutionContextImpl ec = new ExecutionContextImpl(ctx, null, new HashMap<String, Object>());
+        Assert.assertNull(ec.getFlushMode());
+    }
+}


### PR DESCRIPTION
After the property copy loop in `initialise()`, the `flushMode` field is now explicitly initialized from the stored property value. This is needed because `properties.setProperty()` (`BasePropertyStore`) doesn't trigger the special handling in `ExecutionContext.setProperty()` that assigns the field.

Fixes #529

Includes a reproduction test (`ExecutionContextFlushModeTest`) that verifies `getFlushMode()` returns the configured value after EC construction.