### PR TITLE
Feat: add a configuration to control maximum exceptions can be collect when processing persistence

### DIFF
--- a/src/main/java/org/datanucleus/ExecutionContext.java
+++ b/src/main/java/org/datanucleus/ExecutionContext.java
@@ -1026,6 +1026,15 @@ public interface ExecutionContext extends ExecutionContextReference
     boolean containsStateManagerAssociatedValue(DNStateManager sm, Object key);
 
     /**
+     * Maximum nested exception can be collected, when collected exceptions greater or equal to this value,
+     * the persist process will throw Exception for fast-failed.
+     * @return maximum nested exception can be collected.
+     *         default value is Integer.MAX_VALUE, which means no limit,
+     *         minimum value is 1, which means only one exception can be collected.
+     */
+    int getMaximumCollectNestedExceptions();
+
+    /**
      * Register a listener to be called when this ExecutionContext is closing.
      * @param listener The listener
      */

--- a/src/main/java/org/datanucleus/ExecutionContextImpl.java
+++ b/src/main/java/org/datanucleus/ExecutionContextImpl.java
@@ -1422,7 +1422,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
 
     /**
      * Method called when a non-tx update has been performed (via setter call on the persistable object, or via
-     * use of mutator methods of a field). Only hands the update across to be "committed" if not part of an owning 
+     * use of mutator methods of a field). Only hands the update across to be "committed" if not part of an owning
      * persist/delete call.
      */
     public void processNontransactionalUpdate()
@@ -1502,6 +1502,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                 // "commit" all enlisted StateManagers
                 ApiAdapter api = getApiAdapter();
                 DNStateManager[] sms = enlistedSMCache.values().toArray(new DNStateManager[enlistedSMCache.size()]);
+                int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
                 for (int i = 0; i < sms.length; ++i)
                 {
                     try
@@ -1523,6 +1524,9 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                             failures = new ArrayList<>();
                         }
                         failures.add(e);
+                        if (failures.size() >= maximumCollectNestedExceptions) {
+                            throw new CommitStateTransitionException(failures.toArray(new Exception[failures.size()]));
+                        }
                     }
                 }
             }
@@ -1692,6 +1696,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
         }
 
         List<Throwable> failures = null;
+        int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
         for (DNStateManager sm : toRefresh)
         {
             try
@@ -1705,6 +1710,9 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                     failures = new ArrayList<>();
                 }
                 failures.add(e);
+                if (failures.size() >= maximumCollectNestedExceptions) {
+                    throw new NucleusUserException(Localiser.msg("010037"), failures.toArray(new Exception[failures.size()]));
+                }
             }
         }
 
@@ -1724,6 +1732,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
 
         // TODO Consider doing these in bulk where possible if several objects of the same type
         List<Throwable> failures = null;
+        int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
         for (Object pc : pcs)
         {
             if (pc == null)
@@ -1751,6 +1760,9 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                     failures = new ArrayList<>();
                 }
                 failures.add(e);
+                if (failures.size() >= maximumCollectNestedExceptions) {
+                    throw new NucleusUserException(Localiser.msg("010037"), failures.toArray(new Exception[failures.size()]));
+                }
             }
             finally
             {
@@ -1870,6 +1882,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
             {
                 getStoreManager().getPersistenceHandler().batchStart(this, PersistenceBatchType.PERSIST);
                 List<RuntimeException> failures = null;
+                int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
                 for (int i=0;i<objs.length;i++)
                 {
                     try
@@ -1886,6 +1899,15 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                             failures = new ArrayList<>();
                         }
                         failures.add(e);
+                        if (failures.size() >= maximumCollectNestedExceptions) {
+                            RuntimeException ex = failures.get(0);
+                            if (ex instanceof NucleusException && ((NucleusException)ex).isFatal())
+                            {
+                                // Should really check all and see if any are fatal not just first one
+                                throw new NucleusFatalUserException(Localiser.msg("010039"), failures.toArray(new Exception[failures.size()]));
+                            }
+                            throw new NucleusUserException(Localiser.msg("010039"), failures.toArray(new Exception[failures.size()]));
+                        }
                     }
                 }
                 if (failures != null && !failures.isEmpty())
@@ -2179,6 +2201,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
             getStoreManager().getPersistenceHandler().batchStart(this, PersistenceBatchType.DELETE);
 
             List<RuntimeException> failures = null;
+            int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
             for (int i=0;i<objs.length;i++)
             {
                 try
@@ -2195,6 +2218,15 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                         failures = new ArrayList<>();
                     }
                     failures.add(e);
+                    if (failures.size() >= maximumCollectNestedExceptions) {
+                        RuntimeException ex = failures.get(0);
+                        if (ex instanceof NucleusException && ((NucleusException)ex).isFatal())
+                        {
+                            // Should really check all and see if any are fatal not just first one
+                            throw new NucleusFatalUserException(Localiser.msg("010040"), failures.toArray(new Exception[failures.size()]));
+                        }
+                        throw new NucleusUserException(Localiser.msg("010040"), failures.toArray(new Exception[failures.size()]));
+                    }
                 }
             }
             if (failures != null && !failures.isEmpty())
@@ -4521,6 +4553,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
             // Commit all enlisted StateManagers
             ApiAdapter api = getApiAdapter();
             DNStateManager[] sms = enlistedSMCache.values().toArray(new DNStateManager[enlistedSMCache.size()]);
+            int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
             for (int i = 0; i < sms.length; ++i)
             {
                 try
@@ -4547,6 +4580,9 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                         failures = new ArrayList<>();
                     }
                     failures.add(e);
+                    if (failures.size() >= maximumCollectNestedExceptions) {
+                        throw new CommitStateTransitionException(failures.toArray(new Exception[failures.size()]));
+                    }
                 }
             }
         }
@@ -4566,6 +4602,7 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
     public void preRollback()
     {
         List<Throwable> failures = null;
+        int maximumCollectNestedExceptions = this.getMaximumCollectNestedExceptions();
         try
         {
             for (DNStateManager sm : enlistedSMCache.values())
@@ -4586,12 +4623,15 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
                         failures = new ArrayList<>();
                     }
                     failures.add(e);
+                    if (failures.size() >= maximumCollectNestedExceptions) {
+                        throw new RollbackStateTransitionException(failures.toArray(new Exception[failures.size()]));
+                    }
                 }
             }
-            clearDirty();
         }
         finally
         {
+            clearDirty();
             resetTransactionalVariables();
         }
 
@@ -5870,6 +5910,11 @@ public class ExecutionContextImpl implements ExecutionContext, TransactionEventL
             return stateManagerAssociatedValuesMap.get(sm).containsKey(key);
         }
         return false;
+    }
+
+    @Override
+    public int getMaximumCollectNestedExceptions() {
+        return Math.max(1, nucCtx.getConfiguration().getIntProperty(PropertyNames.PROPERTY_PERSISTENCE_MAXIMUM_COLLECT_NESTED_EXCEPTIONS));
     }
 
     /**

--- a/src/main/java/org/datanucleus/PersistenceNucleusContextImpl.java
+++ b/src/main/java/org/datanucleus/PersistenceNucleusContextImpl.java
@@ -302,6 +302,7 @@ public class PersistenceNucleusContextImpl extends AbstractNucleusContext implem
         conf.addDefaultBooleanProperty(PropertyNames.PROPERTY_QUERY_RESULTCACHE_VALIDATEOBJECTS, null, true, false, false);
         conf.addDefaultProperty(PropertyNames.PROPERTY_QUERY_RESULT_SIZE_METHOD, null, "last", null, false, false);
         conf.addDefaultBooleanProperty(PropertyNames.PROPERTY_QUERY_COMPILE_NAMED_QUERIES_AT_STARTUP, null, false, false, false);
+        conf.addDefaultIntegerProperty(PropertyNames.PROPERTY_PERSISTENCE_MAXIMUM_COLLECT_NESTED_EXCEPTIONS, null, Integer.MAX_VALUE, false, false);
 
         // Other properties
         conf.addDefaultBooleanProperty(PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT, null, true, false, true);

--- a/src/main/java/org/datanucleus/PropertyNames.java
+++ b/src/main/java/org/datanucleus/PropertyNames.java
@@ -77,6 +77,7 @@ public class PropertyNames
     public static final String PROPERTY_USE_IMPLEMENTATION_CREATOR = "datanucleus.useImplementationCreator".toLowerCase();
 
     public static final String PROPERTY_RELATION_IDENTITY_STORAGE_MODE = "datanucleus.relation.identityStorageMode".toLowerCase();
+    public static final String PROPERTY_PERSISTENCE_MAXIMUM_COLLECT_NESTED_EXCEPTIONS = "datanucleus.persistence.maximumCollectNestedExceptions".toLowerCase();
 
     public static final String PROPERTY_TYPE_WRAPPER_BASIS = "datanucleus.type.wrapper.basis";
     public static final String PROPERTY_TYPE_TREAT_JAVA_UTIL_DATE_AS_MUTABLE = "datanucleus.type.treatJavaUtilDateAsMutable".toLowerCase();


### PR DESCRIPTION
This PR adds a parameter to control the maximum number of exceptions that can be caught during persistence operations. 

Currently, some operations in `PersistenceManager` and `ExecutionContext` iterate over the fields of the passed-in objects and capture all exceptions in an ArrayList. In certain scenarios (e.g., lost or disconnected database connections), the iteration process throws exceptions (the iterator's state is not updated due to the exception), and these exceptions are caught by the outer layer, causing the iteration to continue, potentially leading to an infinite loop. Furthermore, storing a large number of exceptions in the ArrayList can cause JVM memory usage to spike, potentially resulting in an OutOfMemoryError.

We've added a parameter `datanucleus.persistence.maximumCollectNestedExceptions`, which specifies the maximum number of exceptions that can be caught. The default value is `Integer.MAX_VALUE`, ensuring consistency with existing behavior. Users can configure this parameter, with a minimum value of 1. When the number of exceptions thrown during the iteration operation exceeds or equals this value, the iteration operation will be fast-failed quickly to avoid an infinite loop.

Also, please note that PR datanucleus/datanucleus-api-jdo#145 uses the newly added parameters.

Fixes #540 